### PR TITLE
Compile fixes for Fedora 14 and up

### DIFF
--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -114,12 +114,12 @@ static void push_column(lua_State *L, sqlite3_stmt *vm, int column) {
     lua_pushnumber(L, sqlite3_column_double(vm, column));
     break;
   case SQLITE_TEXT:
-    lua_pushlstring(L, sqlite3_column_text(vm, column),
-		    sqlite3_column_bytes(vm, column));
+    lua_pushlstring(L, (const char *)sqlite3_column_text(vm, column),
+		    (size_t)sqlite3_column_bytes(vm, column));
     break;
   case SQLITE_BLOB:
     lua_pushlstring(L, sqlite3_column_blob(vm, column),
-		    sqlite3_column_bytes(vm, column));
+		    (size_t)sqlite3_column_bytes(vm, column));
     break;
   case SQLITE_NULL:
     lua_pushnil(L);
@@ -519,7 +519,7 @@ static int env_connect(lua_State *L)
     }
 
   if (lua_isnumber(L, 3)) {
-  	sqlite3_busy_timeout(conn, lua_tonumber(L,3)); // TODO: remove this
+  	sqlite3_busy_timeout(conn, lua_tonumber(L,3)); /* TODO: remove this */
   }
 
   return create_connection(L, 1, conn);
@@ -546,14 +546,14 @@ static int env_close (lua_State *L)
 
 /*
 ** Sets the timeout for a lock in the connection.
-*/
 static int opts_settimeout  (lua_State *L)
 {
 	conn_data *conn = getconnection(L);
 	int milisseconds = luaL_checknumber(L, 2);
-	lua_pushnumber(L, sqlite3_busy_timeout(conn, milisseconds));
+	lua_pushnumber(L, sqlite3_busy_timeout(conn->sql_conn, milisseconds));
 	return 1;
 }
+*/
 
 /*
 ** Create metatables for each class of object.


### PR DESCRIPTION
This patch fixes some minor issues with the sqlite3 integration apparent on Fedora 14 and up with LuaSQL 2.2.0.
