### PR TITLE
Added support for wchar, wvarchar and wlongvarchar types

### DIFF
--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -150,6 +150,7 @@ static const char *sqltypetolua (const SQLSMALLINT type) {
         case SQL_TYPE_DATE: case SQL_TYPE_TIME: case SQL_TYPE_TIMESTAMP: 
         case SQL_DATE: case SQL_INTERVAL: case SQL_TIMESTAMP: 
         case SQL_LONGVARCHAR:
+        case SQL_WCHAR: case SQL_WVARCHAR: case SQL_WLONGVARCHAR:
             return "string";
         case SQL_BIGINT: case SQL_TINYINT: case SQL_NUMERIC: 
         case SQL_DECIMAL: case SQL_INTEGER: case SQL_SMALLINT: 


### PR DESCRIPTION
This adds support for the mentioned column types. I have been using this in production for several years with no problems whatsoever. A reader on the Lua list had a similar issue with Oracle, so I decided to send the change for good.
