### PR TITLE
Added support for PRAGMA queries to SQLite3

### DIFF
--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -382,7 +382,7 @@ static int conn_execute(lua_State *L)
   int numcols;
   const char *tail;
 
-  res = sqlite3_prepare(conn->sql_conn, statement, -1, &vm, &tail);
+  res = sqlite3_prepare_v2(conn->sql_conn, statement, -1, &vm, &tail);
   if (res != SQLITE_OK)
     {
       errmsg = sqlite3_errmsg(conn->sql_conn);


### PR DESCRIPTION
This is a simple patch to make SQLite3 be able to properly use PRAGMAs in queries.
