### PR TITLE
Use relative link to doc.css : prevent mixed https/http  content

### DIFF
--- a/doc/br/examples.html
+++ b/doc/br/examples.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>LuaSQL: Conectividade de banco de dados para a linguagem de programa&ccedil;&atilde;o Lua</title>
-    <link rel="stylesheet" href="http://www.keplerproject.org/doc.css" type="text/css"/>
+    <link rel="stylesheet" href="doc.css" type="text/css"/>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/doc/br/history.html
+++ b/doc/br/history.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>LuaSQL: Conectividade de banco de dados para a linguagem de programa&ccedil;&atilde;o Lua</title>
-    <link rel="stylesheet" href="http://www.keplerproject.org/doc.css" type="text/css"/>
+    <link rel="stylesheet" href="doc.css" type="text/css"/>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 

--- a/doc/br/index.html
+++ b/doc/br/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>LuaSQL: Conectividade de banco de dados para a linguagem de programa&ccedil;&atilde;o Lua</title>
-    <link rel="stylesheet" href="http://www.keplerproject.org/doc.css" type="text/css"/>
+    <link rel="stylesheet" href="doc.css" type="text/css"/>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 

--- a/doc/br/license.html
+++ b/doc/br/license.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Licen&ccedil;a LuaSQL</title>
-    <link rel="stylesheet" href="http://www.keplerproject.org/doc.css" type="text/css"/>
+    <link rel="stylesheet" href="doc.css" type="text/css"/>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 

--- a/doc/br/manual.html
+++ b/doc/br/manual.html
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>LuaSQL: Conectividade de banco de dados para a linguagem de programa&ccedil;&atilde;o Lua</title>
-    <link rel="stylesheet" href="http://www.keplerproject.org/doc.css" type="text/css"/>
+    <link rel="stylesheet" href="doc.css" type="text/css"/>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 


### PR DESCRIPTION
Like the 'us' doc.
Use relative link to doc.css : prevent mixed https/http content
