### PR TITLE
tests/odbc.lua - fixed typo in variable name

### DIFF
--- a/tests/odbc.lua
+++ b/tests/odbc.lua
@@ -27,5 +27,5 @@ table.insert (EXTENSIONS, function ()
 	assert2 (true, row.f3, "Wrong bit representation")
 
 	-- Drops the table
-    assert2 (DROP_TABLE_RETURN_VALUE0, CONN:execute("drop table test_dt") )
+    assert2 (DROP_TABLE_RETURN_VALUE, CONN:execute("drop table test_dt") )
 end)


### PR DESCRIPTION
Fixed typo in DROP_TABLE_RETURN_VALUE variable name in assert2 statement on line 30.