### PR TITLE
Call PQfinish after PQerrorMessage when connection fails

### DIFF
--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -510,8 +510,9 @@ static int env_connect (lua_State *L) {
 	conn = PQsetdbLogin(pghost, pgport, NULL, NULL, sourcename, username, password);
 
 	if (PQstatus(conn) == CONNECTION_BAD) {
+		int rc = luasql_failmsg(L, "error connecting to database. PostgreSQL: ", PQerrorMessage(conn));
 		PQfinish(conn);
-		return luasql_failmsg(L, "error connecting to database. PostgreSQL: ", PQerrorMessage(conn));
+		return rc;
 	}
 	PQsetNoticeProcessor(conn, notice_processor, NULL);
 	return create_connection(L, 1, conn);


### PR DESCRIPTION
Per #45 and dac9faf47c4eb2e47f1e64eb0d98ce37016b7d4d (comment inline)

Avoid a Valgrind invalid read from a stale PGconn pointer.