### PR TITLE
Use <stdlib.h> instead of deprecated <malloc.h>

### DIFF
--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -6,7 +6,7 @@
 
 #include <ibase.h>	/* The Firebird API*/
 #include <time.h>	/* For managing time values */
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Lua API */


### PR DESCRIPTION
Fixes build failure on e.g. FreeBSD