### PR TITLE
silence a compiler warning in src/ls_mysql.c

### DIFF
--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -183,7 +183,7 @@ static void create_colinfo (lua_State *L, cur_data *cur) {
 /*
 ** Closes the cursos and nullify all structure fields.
 */
-static int cur_nullify (lua_State *L, cur_data *cur) {
+static void cur_nullify (lua_State *L, cur_data *cur) {
 	/* Nullify structure fields. */
 	cur->closed = 1;
 	mysql_free_result(cur->my_res);


### PR DESCRIPTION
From recent master:

$ make mysql
[...snip...]
src/ls_mysql.c: In function `cur_nullify':
src/ls_mysql.c:193: warning: control reaches end of non-void function
$

s/int/void/ to match function prototype in other database connectors