### PR TITLE
Rockspecs for version 2.3.4

### DIFF
--- a/rockspec/luasql-mysql-2.3.4-1.rockspec
+++ b/rockspec/luasql-mysql-2.3.4-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-MySQL"
+version = "2.3.4-1"
+source = {
+  url = "git://github.com/keplerproject/luasql.git",
+  branch = "v2.3.4",
+}
+description = {
+   summary = "Database connectivity for Lua (MySQL driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   MYSQL = {
+      header = "mysql.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.mysql"] = {
+       sources = { "src/luasql.c", "src/ls_mysql.c" },
+       libraries = { "mysqlclient" },
+       incdirs = { "$(MYSQL_INCDIR)" },
+       libdirs = { "$(MYSQL_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-oci8-2.3.4-1.rockspec
+++ b/rockspec/luasql-oci8-2.3.4-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-OCI8"
+version = "2.3.4-1"
+source = {
+  url = "git://github.com/keplerproject/luasql.git",
+  branch = "v2.3.4",
+}
+description = {
+   summary = "Database connectivity for Lua (Oracle driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   OCI8 = {
+      header = "oci.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.oci8"] = {
+       sources = { "src/luasql.c", "src/ls_oci8.c" },
+       libraries = { "z", "clntsh", },
+       incdirs = { "$(OCI8_INCDIR)" },
+       libdirs = { "$(OCI8_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-odbc-2.3.4-1.rockspec
+++ b/rockspec/luasql-odbc-2.3.4-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-ODBC"
+version = "2.3.4-1"
+source = {
+  url = "git://github.com/keplerproject/luasql.git",
+  branch = "v2.3.4",
+}
+description = {
+   summary = "Database connectivity for Lua (ODBC driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ODBC = {
+      header = "sql.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.odbc"] = {
+       sources = { "src/luasql.c", "src/ls_odbc.c" },
+       libraries = { "odbc" },
+       incdirs = { "$(ODBC_INCDIR)" },
+       libdirs = { "$(ODBC_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite-2.3.4-1.rockspec
+++ b/rockspec/luasql-sqlite-2.3.4-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-SQLite"
+version = "2.3.4-1"
+source = {
+  url = "git://github.com/keplerproject/luasql.git",
+  branch = "v2.3.4",
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite.c" },
+       libraries = { "sqlite" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite3-2.3.4-1.rockspec
+++ b/rockspec/luasql-sqlite3-2.3.4-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-SQLite3"
+version = "2.3.4-1"
+source = {
+  url = "git://github.com/keplerproject/luasql.git",
+  branch = "v2.3.4",
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite3 driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite3.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite3"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite3.c" },
+       libraries = { "sqlite3" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}


### PR DESCRIPTION
Since version 2.3.4 was tagged in the source code, it's better to release matching rockspecs for all drivers to avoid confusion, and make the latest code more widely available. This also solves long standing compatibility issues.

Closes #6. (Lua 5.2 compatibility for odbc)
Closes #30. (Lua 5.3 support for luasql-mysql)
(And it possibly closes more issues as well!)

Please upload these rockspecs to luarocks.org after merging using `luarocks upload <file.rockspec>`, so that the .src.rock files get generated and uploaded as well. Thank you!