### PR TITLE
fixing leak of mysql thread handlers

### DIFF
--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -532,6 +532,7 @@ static int env_close (lua_State *L) {
 		lua_pushboolean (L, 0);
 		return 1;
 	}
+	mysql_server_end();
 	env->closed = 1;
 	lua_pushboolean (L, 1);
 	return 1;

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -532,7 +532,7 @@ static int env_close (lua_State *L) {
 		lua_pushboolean (L, 0);
 		return 1;
 	}
-	mysql_server_end();
+	mysql_library_end();
 	env->closed = 1;
 	lua_pushboolean (L, 1);
 	return 1;


### PR DESCRIPTION
fixing issue #22.
I see that there is no either mysql_library_end or mysql_server_end that should free resource handler allocated by mysql_init
That is why when use library with Apache that fork child and keep child alive reusing library at lua scripts cause leak of thread handlers and error
LuaSQL: error connecting: Out of memory.
along with libmysqlclient library error
Can't initialize threads: error 11

and following stack obtained with strace
libmysqlclient.so(my_thread_global_init
libmysqlclient.so(my_init
libmysqlclient.so(mysql_server_init
libmysqlclient.so(mysql_init
mysql.so(env_connect
luajit(luaL_openlibs
