### PR TITLE
fix memory db connection creating and using file based db

### DIFF
--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -554,7 +554,14 @@ static int env_connect(lua_State *L)
   sourcename = luaL_checkstring(L, 2);
 
 #if SQLITE_VERSION_NUMBER > 3006013
-  res = sqlite3_open_v2(sourcename, &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+  if (strstr(sourcename, ":memory:")) /* TODO: rework this and get/add param 'flag' for sqlite3_open_v2 - see TODO below */
+  {
+	  res = sqlite3_open_v2(sourcename, &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_MEMORY, NULL);
+  }
+  else
+  {
+	  res = sqlite3_open_v2(sourcename, &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+  }
 #else
   res = sqlite3_open(sourcename, &conn);
 #endif


### PR DESCRIPTION
This isn't documented well @ http://www.sqlite.org/inmemorydb.html since sqlite3_open() is obsolete.
SQLITE_OPEN_CREATE flag avoids the usage of pure memory databases. If this flag is set a db file is created and referenced.
SQLITE_OPEN_MEMORY flag works as expected.

Is there any info about line 577? I would like to add an argument for all possible flags (see sqlite3.h 'Flags For File Open Operations') but args 4 doesn't seem to be future-proof.