### PR TITLE
Support building with newer MariaDB versions

### DIFF
--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -603,7 +603,11 @@ LUASQL_API int luaopen_luasql_mysql (lua_State *L) {
 	luaL_setfuncs(L, driver, 0);
 	luasql_set_info (L);
     lua_pushliteral (L, "_CLIENTVERSION");
-    lua_pushliteral (L, MYSQL_SERVER_VERSION);
+#ifdef MARIADB_CLIENT_VERSION_STR
+    lua_pushliteral (L, MARIADB_CLIENT_VERSION_STR);
+#else
+    lua_pushliteral (L, MYSQL__VERSION);
+#endif
     lua_settable (L, -3);
 	return 1;
 }


### PR DESCRIPTION
Recent versions of mysql.h, as provided by MariaDB, do not include
mysql_version.h anymore, but use mariadb_version.h instead, which
defines MARIADB_CLIENT_VERSION_STR.