### PR TITLE
Executing stored procedures in Firebird driver works

### DIFF
--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -335,7 +335,7 @@ static int conn_execute (lua_State *L) {
 	}
 
 	/* an unsupported SQL statement (something like COMMIT) */
-	if(stmt_type > 5) {
+	if(stmt_type > isc_info_sql_stmt_ddl && stmt_type != isc_info_sql_stmt_exec_procedure) {
 		free(cur.out_sqlda);
 		return luasql_faildirect(L, "unsupported SQL statement");
 	}


### PR DESCRIPTION
Statements like that:
`execute procedure Foo(5);`
didn't work for the  Firebird driver.

According to the documentation they have statement code 8. In current version of driver this code
 is prohibited. But if procedure has returning values it will work:
`select * from Foo(5);` because it is a "select" statement. It so strange, and I have decided to path that.