### PR TITLE
Added support for handling Procedures and Returning SQL

### DIFF
--- a/src/ls_firebird.c
+++ b/src/ls_firebird.c
@@ -335,7 +335,15 @@ static int conn_execute (lua_State *L) {
 	}
 
 	/* an unsupported SQL statement (something like COMMIT) */
-	if(stmt_type > 5) {
+	switch(stmt.type) {
+	case isc_info_sql_stmt_select:
+	case isc_info_sql_stmt_insert:
+	case isc_info_sql_stmt_update:
+	case isc_info_sql_stmt_delete:
+	case isc_info_sql_stmt_ddl:
+	case isc_info_sql_stmt_exec_procedure:
+		break;
+	default:
 		free(cur.out_sqlda);
 		return luasql_faildirect(L, "unsupported SQL statement");
 	}
@@ -700,11 +708,17 @@ static void push_column(lua_State *L, int i, cur_data *cur) {
 */
 static int cur_fetch (lua_State *L) {
 	ISC_STATUS fetch_stat;
-	int i;
-	cur_data *cur = getcursor(L,1);
+	int i, res;
+	cur_data *cur = (cur_data *)luaL_checkudata (L, 1, LUASQL_CURSOR_FIREBIRD);
 	const char *opts = luaL_optstring (L, 3, "n");
 	int num = strchr(opts, 'n') != NULL;
 	int alpha = strchr(opts, 'a') != NULL;
+
+	/* check cursor status */
+	luaL_argcheck (L, cur != NULL, 1, "cursor expected");
+	if (cur->closed) {
+		return 0;
+	}
 
 	if ((fetch_stat = isc_dsql_fetch(cur->env->status_vector, &cur->stmt, 1, cur->out_sqlda)) == 0) {
 		if (lua_istable (L, 2)) {
@@ -715,13 +729,13 @@ static int cur_fetch (lua_State *L) {
 			for (i = 0; i < cur->out_sqlda->sqld; i++) {
 				push_column(L, i, cur);
 
-				if( num ) {
+				if (num) {
 					lua_pushnumber(L, i+1);
 					lua_pushvalue(L, -2);
 					lua_settable(L, 2);
 				}
 
-				if( alpha ) {
+				if (alpha) {
 					lua_pushlstring(L, cur->out_sqlda->sqlvar[i].aliasname, cur->out_sqlda->sqlvar[i].aliasname_length);
 					lua_pushvalue(L, -2);
 					lua_settable(L, 2);
@@ -731,14 +745,22 @@ static int cur_fetch (lua_State *L) {
 			}
 
 			/* returning given table */
-			return 1;
+			res = 1;
 		} else {
 			for (i = 0; i < cur->out_sqlda->sqld; i++)
 				push_column(L, i, cur);
 
 			/* returning a list of values */
-			return cur->out_sqlda->sqld;
+			res = cur->out_sqlda->sqld;
 		}
+
+		/* close cursor for procedures/returnings as they (currently) only
+		   return one result, and error on subsequent fetches */
+		if (cur->stmt->type == isc_info_sql_stmt_exec_procedure) {
+			cur_shut(L, cur);
+		}
+
+		return res;
 	}
 
 	/* isc_dsql_fetch returns 100 if no more rows remain to be retrieved

--- a/tests/firebird.lua
+++ b/tests/firebird.lua
@@ -15,9 +15,36 @@ function create_table ()
 end
 
 function drop_table ()
+	-- Firebird prefers to keep DDL stuff (CREATE TABLE, etc.) 
+	-- seperate. So we need a new transaction i.e. connection
+	-- to work in
+	assert(CONN:close ())
+	CONN = assert(ENV:connect (datasource, username, password))
 	orig_drop_table()
 	CONN:commit()
 end
 
 table.insert (CONN_METHODS, "escape")
 table.insert (EXTENSIONS, escape)
+
+-- Check RETURNING support
+table.insert (EXTENSIONS, function()
+	local cur = assert (CONN:execute[[
+EXECUTE BLOCK
+RETURNS (A INTEGER, B INTEGER)
+AS
+BEGIN
+  A = 123;
+  B = 321;
+  SUSPEND;
+END
+]])
+
+	local f1, f2 = cur:fetch ()
+	assert2 (123, f1)
+	assert2 (321, f2)
+	cur:close ()
+	
+	io.write (" returning")
+end)
+


### PR DESCRIPTION
Things such as:
  * `INSERT INTO ... RETURNING SomeCol1, SomeCol2`
  * `EXECUTE BLOCK ... RETURNS ...`
  * `EXECUTE PROCEDURE ... RETURNING ...`

Currently Firebird only supports returning one row from such actions.