### PR TITLE
Basic support for prepared statements in postgres and sqlite3.

### DIFF
--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -219,8 +219,9 @@ method.</p>
 	the operation could not be performed or when it is not implemented.</dd>
 	
 	
-	<dt><a name="conn_execute"></a><strong><code>conn:execute(statement)</code></strong></dt>
-	<dd>Executes the given SQL <code>statement</code>.<br/>
+	<dt><a name="conn_execute"></a><strong><code>conn:execute(statement[,...])</code></strong></dt>
+	<dd>Executes the given SQL <code>statement</code>. As in traditional prepared statements,
+	additional parameters can be used to avoid SQL injections, though not all drivers support this.<br/>
 	Returns: a <a href="#cursor_object">cursor object</a>
 	if there are results, or the number of rows affected by the command otherwise.</dd>
 	

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -379,6 +379,7 @@ static int conn_escape(lua_State *L)
 */
 static int conn_execute(lua_State *L)
 {
+  int i;
   conn_data *conn = getconnection(L);
   const char *statement = luaL_checkstring(L, 2);
   int res;
@@ -396,6 +397,52 @@ static int conn_execute(lua_State *L)
     {
       errmsg = sqlite3_errmsg(conn->sql_conn);
       return luasql_faildirect(L, errmsg);
+    }
+
+  /* bind any additional arguments to the statement */
+  numcols = lua_gettop(L);
+  for (i = 3; i <= numcols; i++)
+    {
+      const char * buffer;
+      size_t size;
+      switch (lua_type(L, i)) {
+      case LUA_TNIL:
+        res = sqlite3_bind_null(vm, i - 2);
+        break;
+
+      case LUA_TBOOLEAN:
+      case LUA_TNUMBER:
+#ifdef LUA_INT_TYPE
+        if (lua_isnumber(L, i) && !lua_isinteger(L, i))
+          {
+            res = sqlite3_bind_double(vm, i - 2, lua_tonumber(L, i));
+          }
+        else
+          {
+            res = sqlite3_bind_int64(vm, i - 2, lua_tointeger(L, i));
+          }
+#else
+	res = sqlite3_bind_double(vm, i - 2, lua_tonumber(L, i));
+#endif
+        break;
+
+      case LUA_TSTRING:
+        buffer = lua_tolstring(L, i, &size);
+        res = sqlite3_bind_blob(vm, i - 2, buffer, size, SQLITE_TRANSIENT);
+        break;
+
+      default:
+        sqlite3_finalize(vm);
+        return luaL_error(L, LUASQL_PREFIX"Invalid type for execute parameter %d", i - 2);
+      }
+
+      /* handle errors */
+      if (res != SQLITE_OK)
+        {
+          errmsg = sqlite3_errmsg(conn->sql_conn);
+          sqlite3_finalize(vm);
+          return luaL_error(L, LUASQL_PREFIX"Error binding parameter %d: %s", i - 2, errmsg);
+        }
     }
 
   /* process first result to retrive query information and type */

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -428,7 +428,7 @@ static int conn_execute(lua_State *L)
 
       case LUA_TSTRING:
         buffer = lua_tolstring(L, i, &size);
-        res = sqlite3_bind_blob(vm, i - 2, buffer, size, SQLITE_TRANSIENT);
+        res = sqlite3_bind_text(vm, i - 2, buffer, size, SQLITE_TRANSIENT);
         break;
 
       default:


### PR DESCRIPTION
With this modification we can enjoy the security benefits of having
prepared-statement-alike additional parameters.  To do this, the
additional parameters should be passed after the statement in the
execute method.

This means that a new prepared statement will be created on each
execute call, so don't expect a huge performance increase. This is
done for safety reasons.