### PR TITLE
Reusable Prepare Statements on MySQL (plus basic support for postgres and sqlite3)

### DIFF
--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -219,8 +219,9 @@ method.</p>
 	the operation could not be performed or when it is not implemented.</dd>
 	
 	
-	<dt><a name="conn_execute"></a><strong><code>conn:execute(statement)</code></strong></dt>
-	<dd>Executes the given SQL <code>statement</code>.<br/>
+	<dt><a name="conn_execute"></a><strong><code>conn:execute(statement[,...])</code></strong></dt>
+	<dd>Executes the given SQL <code>statement</code>. As in traditional prepared statements,
+	additional parameters can be used to avoid SQL injections, though not all drivers support this.<br/>
 	Returns: a <a href="#cursor_object">cursor object</a>
 	if there are results, or the number of rows affected by the command otherwise.</dd>
 	

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -221,7 +221,8 @@ method.</p>
 	
 	<dt><a name="conn_execute"></a><strong><code>conn:execute(statement[,...])</code></strong></dt>
 	<dd>Executes the given SQL <code>statement</code>. As in traditional prepared statements,
-	additional parameters can be used to avoid SQL injections, though not all drivers support this.<br/>
+	additional parameters can be used to avoid SQL injections. Although this is only
+	supported by sqlite3, postgres and mysql drivers.<br/>
 	Returns: a <a href="#cursor_object">cursor object</a>
 	if there are results, or the number of rows affected by the command otherwise.</dd>
 	

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -379,6 +379,7 @@ static int conn_escape(lua_State *L)
 */
 static int conn_execute(lua_State *L)
 {
+  int i;
   conn_data *conn = getconnection(L);
   const char *statement = luaL_checkstring(L, 2);
   int res;
@@ -396,6 +397,52 @@ static int conn_execute(lua_State *L)
     {
       errmsg = sqlite3_errmsg(conn->sql_conn);
       return luasql_faildirect(L, errmsg);
+    }
+
+  /* bind any additional arguments to the statement */
+  numcols = lua_gettop(L);
+  for (i = 3; i <= numcols; i++)
+    {
+      const char * buffer;
+      size_t size;
+      switch (lua_type(L, i)) {
+      case LUA_TNIL:
+        res = sqlite3_bind_null(vm, i - 2);
+        break;
+
+      case LUA_TBOOLEAN:
+      case LUA_TNUMBER:
+#ifdef LUA_INT_TYPE
+        if (lua_isnumber(L, i) && !lua_isinteger(L, i))
+          {
+            res = sqlite3_bind_double(vm, i - 2, lua_tonumber(L, i));
+          }
+        else
+          {
+            res = sqlite3_bind_int64(vm, i - 2, lua_tointeger(L, i));
+          }
+#else
+	res = sqlite3_bind_double(vm, i - 2, lua_tonumber(L, i));
+#endif
+        break;
+
+      case LUA_TSTRING:
+        buffer = lua_tolstring(L, i, &size);
+        res = sqlite3_bind_blob(vm, i - 2, buffer, size, SQLITE_TRANSIENT);
+        break;
+
+      default:
+        sqlite3_finalize(vm);
+        return luaL_error(L, LUASQL_PREFIX"Invalid type for execute parameter %d", i - 2);
+      }
+
+      /* handle errors */
+      if (res != SQLITE_OK)
+        {
+          errmsg = sqlite3_errmsg(conn->sql_conn);
+          sqlite3_finalize(vm);
+          return luaL_error(L, LUASQL_PREFIX"Error binding parameter %d: %s", i - 2, errmsg);
+        }
     }
 
   /* process first result to retrive query information and type */

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -428,7 +428,7 @@ static int conn_execute(lua_State *L)
 
       case LUA_TSTRING:
         buffer = lua_tolstring(L, i, &size);
-        res = sqlite3_bind_blob(vm, i - 2, buffer, size, SQLITE_TRANSIENT);
+        res = sqlite3_bind_text(vm, i - 2, buffer, size, SQLITE_TRANSIENT);
         break;
 
       default:

--- a/src/luasql.h
+++ b/src/luasql.h
@@ -29,6 +29,7 @@ LUASQL_API int luasql_failmsg (lua_State *L, const char *err, const char *m);
 LUASQL_API int luasql_createmeta (lua_State *L, const char *name, const luaL_Reg *methods);
 LUASQL_API void luasql_setmeta (lua_State *L, const char *name);
 LUASQL_API void luasql_set_info (lua_State *L);
+LUASQL_API int luasql_conn_execute (lua_State *L);
 
 #if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);


### PR DESCRIPTION
This pull request is based on the PR #99, however this one adds additional support for reusing prepared statements.

Example:
```lua
local driver = require 'luasql.mysql'.mysql()

local conn = assert(driver:connect('test'))
assert(conn:setautocommit(false))
assert(conn:execute 'create table if not exists numbers(n int)')
assert(conn:execute 'truncate table numbers')

local t = os.time()
local stmt = assert(conn:prepare('insert into numbers values(?)'..(',(?)'):rep(9)))
for i = 0, 999 do
  for j = i*1000 + 1, i*1000 + 1000, 10 do
    assert(stmt:execute(j, j+1, j+2, j+3, j+4, j+5, j+6, j+7, j+8, j+9))
  end
  print((i+1)*1000 .. ' rows inserted.')
end
assert(conn:commit())
print('inserted a million rows in about ' .. os.time() - t .. ' seconds')
```