### PR TITLE
Fix ODBC types to match standard typedefs

### DIFF
--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -346,7 +346,7 @@ static int push_column(lua_State *L, int coltypes, const SQLHSTMT hstmt,
     switch (type) {
         /* nUmber */
         case 'u': { 
-			double num;
+			SQLDOUBLE num;
 			SQLLEN got;
 			SQLRETURN rc = SQLGetData(hstmt, i, SQL_C_DOUBLE, &num, 0, &got);
 			if (error(rc))
@@ -360,7 +360,7 @@ static int push_column(lua_State *L, int coltypes, const SQLHSTMT hstmt,
 #if LUA_VERSION_NUM>=503
 		/* iNteger */
 		case 'n': {
-			long int num;
+			SQLINTEGER num;
 			SQLLEN got;
 			SQLRETURN rc = SQLGetData(hstmt, i, SQL_C_SLONG, &num, 0, &got);
 			if (error(rc))
@@ -374,7 +374,7 @@ static int push_column(lua_State *L, int coltypes, const SQLHSTMT hstmt,
 #endif
 		/* bOol */
         case 'o': { 
-			char b;
+			SQLCHAR b;
 			SQLLEN got;
 			SQLRETURN rc = SQLGetData(hstmt, i, SQL_C_BIT, &b, 0, &got);
 			if (error(rc))


### PR DESCRIPTION
This fixes a bug that I'm currently experiencing reproducible in the following way:

- Use lua5.3
- `sizeof(long int)` must be 8
- `sizeof(SQLINTEGER)` must be 4
- Select some integer values

Selecting a column of integer type would mess up the values.

Current behavior:
![image](https://user-images.githubusercontent.com/6076005/59506323-38329600-8ea8-11e9-8627-fef1a30fb6af.png)
4 is the "got" size, the mess of numbers is the returned value.

Updated behavior:
![image](https://user-images.githubusercontent.com/6076005/59506556-ceff5280-8ea8-11e9-8ffe-891458a0f455.png)
4 is still the "got" size, the value "2247" is correctly returned.