### PR TITLE
Add an option to env:connect in sqlite3

### DIFF
--- a/doc/br/manual.html
+++ b/doc/br/manual.html
@@ -382,9 +382,10 @@ o driver Oracle ainda oferece uma funcionalidade adicional:</p>
 <p>Al&eacute;m das funcionalidades b&aacute;sicas oferecidas por todos os drivers,
 o driver para SQLite3 ainda oferece uma funcionalidade adicional:</p>
 
-<dt><strong><code>env:connect(sourcename[,locktimeout])</code></strong></dt>
+<dt><strong><code>env:connect(sourcename[,locktimeout,readOnlyMode])</code></strong></dt>
   <dd>No driver para SQLite3, este método tem mais um parâmetro opcional que indica
-    a quantidade de milissegundos para esperar por uma trava de escrita no banco de dados, se ela não for obtida de imediato.<br/>
+    a quantidade de milissegundos para esperar por uma trava de escrita no banco de dados, se ela não for obtida de imediato.
+      TODO: translate me : To connect in readOnlyMode, set readOnlyMode to true<br/>
     Veja tamb&eacute;m: <a href="#environment_object">ambiente</a><br/>
     Retorna: uma <a href="#connection_object">conex&atilde;o</a></dd>
 

--- a/doc/fr/manual.html
+++ b/doc/fr/manual.html
@@ -404,9 +404,10 @@ the Oracle driver also offers this extra feature:</p>
 <p>Besides the basic functionality provided by all drivers,
 the SQLite3 driver also offers this extra feature:</p>
 
-<dt><strong><code>env:connect(sourcename[,locktimeout])</code></strong></dt>
+<dt><strong><code>env:connect(sourcename[,locktimeout, readOnlyMode])</code></strong></dt>
   <dd>In the SQLite3 driver, this method adds an optional parameter
-    that indicate the amount of milisseconds to wait for a write lock if one cannot be obtained immediately.<br/>
+    that indicate the amount of milisseconds to wait for a write lock if one cannot be obtained immediately.
+	  To connect in readOnlyMode, set readOnlyMode to true<br/>
     See also: <a href="#environment_object">environment objects</a><br/>
     Returns: a <a href="#connection_object">connection object</a></dd>
 

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -413,9 +413,10 @@ the Oracle driver also offers this extra feature:</p>
 <p>Besides the basic functionality provided by all drivers,
 the SQLite3 driver also offers this extra feature:</p>
 
-<dt><strong><code>env:connect(sourcename[,locktimeout])</code></strong></dt>
+<dt><strong><code>env:connect(sourcename[,locktimeout,readOnlyMode])</code></strong></dt>
   <dd>In the SQLite3 driver, this method adds an optional parameter
-    that indicate the amount of milliseconds to wait for a write lock if one cannot be obtained immediately.<br/>
+    that indicate the amount of milliseconds to wait for a write lock if one cannot be obtained immediately.
+	  To connect in readOnlyMode, set readOnlyMode to true.<br/>
     See also: <a href="#environment_object">environment objects</a><br/>
     Returns: a <a href="#connection_object">connection object</a></dd>
 

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -7,6 +7,7 @@
 */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -549,19 +550,36 @@ static int env_connect(lua_State *L)
   sqlite3 *conn;
   const char *errmsg;
   int res;
+  bool readOnlyMode = false;
+  int mode;
+
   getenvironment(L);  /* validate environment */
 
-  sourcename = luaL_checkstring(L, 2);
+  if (lua_isboolean(L, 4)) {
+    if (lua_toboolean(L, 4)) {
+      readOnlyMode = true;
+    }
+  }
 
+  sourcename = luaL_checkstring(L, 2);
 #if SQLITE_VERSION_NUMBER > 3006013
   if (strstr(sourcename, ":memory:")) /* TODO: rework this and get/add param 'flag' for sqlite3_open_v2 - see TODO below */
   {
-	  res = sqlite3_open_v2(sourcename, &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_MEMORY, NULL);
+    if (readOnlyMode) {
+      mode = SQLITE_OPEN_READONLY | SQLITE_OPEN_MEMORY;
+    } else {
+      mode = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MEMORY;
+    }
   }
   else
   {
-	  res = sqlite3_open_v2(sourcename, &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+    if (readOnlyMode) {
+      mode = SQLITE_OPEN_READONLY;
+    } else {
+      mode = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+    }
   }
+  res = sqlite3_open_v2(sourcename, &conn, mode, NULL);
 #else
   res = sqlite3_open(sourcename, &conn);
 #endif


### PR DESCRIPTION
Add an option in env:connect in sqlite3 to allow users to connect to the
DB in read only mode.

We use luasql in our code base and have found that it is better to open up a database in readOnlyMode when reading the DB if multiple modules are accessing the database for reads and writes.