### PR TITLE
Update: fix GitHub dropping support for unencrypted git protocol

### DIFF
--- a/rockspec/luasql-firebird-2.6.0-2.rockspec
+++ b/rockspec/luasql-firebird-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-Firebird"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (Firebird driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://keplerproject.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   FB = {
+      header = "ibase.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.firebird"] = {
+       sources = { "src/luasql.c", "src/ls_firebird.c" },
+       libraries = { "fbclient" },
+       incdirs = { "$(FB_INCDIR)" },
+       libdirs = { "$(FB_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-mysql-2.6.0-2.rockspec
+++ b/rockspec/luasql-mysql-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-MySQL"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (MySQL driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   MYSQL = {
+      header = "mysql.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.mysql"] = {
+       sources = { "src/luasql.c", "src/ls_mysql.c" },
+       libraries = { "mysqlclient" },
+       incdirs = { "$(MYSQL_INCDIR)" },
+       libdirs = { "$(MYSQL_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-mysql-cvs-2.rockspec
+++ b/rockspec/luasql-mysql-cvs-2.rockspec
@@ -1,0 +1,34 @@
+package = "LuaSQL-MySQL"
+version = "cvs-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git"
+}
+description = {
+   summary = "Database connectivity for Lua (MySQL driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   MYSQL = {
+      header = "mysql.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.mysql"] = {
+       sources = { "src/luasql.c", "src/ls_mysql.c" },
+       libraries = { "mysqlclient" },
+       incdirs = { "$(MYSQL_INCDIR)" },
+       libdirs = { "$(MYSQL_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-oci8-2.6.0-2.rockspec
+++ b/rockspec/luasql-oci8-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-OCI8"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (Oracle driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   OCI8 = {
+      header = "oci.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.oci8"] = {
+       sources = { "src/luasql.c", "src/ls_oci8.c" },
+       libraries = { "z", "clntsh", },
+       incdirs = { "$(OCI8_INCDIR)" },
+       libdirs = { "$(OCI8_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-odbc-2.6.0-2.rockspec
+++ b/rockspec/luasql-odbc-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-ODBC"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (ODBC driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ODBC = {
+      header = "sql.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.odbc"] = {
+       sources = { "src/luasql.c", "src/ls_odbc.c" },
+       libraries = { "odbc" },
+       incdirs = { "$(ODBC_INCDIR)" },
+       libdirs = { "$(ODBC_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-odbc-cvs-2.rockspec
+++ b/rockspec/luasql-odbc-cvs-2.rockspec
@@ -1,0 +1,37 @@
+package = "LuaSQL-ODBC"
+version = "cvs-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git"
+}
+description = {
+   summary = "Database connectivity for Lua (ODBC driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ODBC = {
+      header = "sql.h"
+   }
+}
+build = {
+   type = "make",
+   variables = {
+      T="odbc",
+      LIB_OPTION = "$(LIBFLAG) -L$(ODBC_LIBDIR) -lodbc",
+      CFLAGS = "$(CFLAGS) -I$(LUA_INCDIR) -I$(ODBC_INCDIR) -DUNIXODBC"
+   },
+   build_variables = {
+      DRIVER_LIBS = "",
+   },
+   install_variables = {
+      LUA_LIBDIR = "$(LIBDIR)",
+   }
+}

--- a/rockspec/luasql-postgres-2.6.0-2.rockspec
+++ b/rockspec/luasql-postgres-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-Postgres"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (Postgres driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://keplerproject.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.0"
+}
+external_dependencies = {
+   PGSQL = {
+      header = "libpq-fe.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.postgres"] = {
+       sources = { "src/luasql.c", "src/ls_postgres.c" },
+       libraries = { "pq" },
+       incdirs = { "$(PGSQL_INCDIR)" },
+       libdirs = { "$(PGSQL_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite-2.6.0-2.rockspec
+++ b/rockspec/luasql-sqlite-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-SQLite"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite.c" },
+       libraries = { "sqlite" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite-cvs-2.rockspec
+++ b/rockspec/luasql-sqlite-cvs-2.rockspec
@@ -1,0 +1,34 @@
+package = "LuaSQL-SQLite"
+version = "cvs-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git"
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite.c" },
+       libraries = { "sqlite" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite3-2.6.0-2.rockspec
+++ b/rockspec/luasql-sqlite3-2.6.0-2.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-SQLite3"
+version = "2.6.0-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git",
+  branch = "2.6.0",
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite3 driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite3.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite3"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite3.c" },
+       libraries = { "sqlite3" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite3-cvs-2.rockspec
+++ b/rockspec/luasql-sqlite3-cvs-2.rockspec
@@ -1,0 +1,34 @@
+package = "LuaSQL-SQLite3"
+version = "cvs-2"
+source = {
+  url = "git+https://github.com/keplerproject/luasql.git"
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite3 driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.keplerproject.org/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite3.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite3"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite3.c" },
+       libraries = { "sqlite3" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}


### PR DESCRIPTION
After some previous brownouts this was finally switched off on 2022/03/15 as notified in:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

This commit provides new `.rockspec` files to change the protocol used to checkout from the GitHub repository so that the rocks can be installed normally. I have created new files with a version suffix that has been incremented so the version string is changed from `2.6.0-1` to `2.6.0-2` in the belief that it will cause the revised files to be sent to those requesting the rock without specifying a version. There are a couple of other `.rockspec` files that do not have a version number (maybe they are the `scm` ones?) but as they do have a `-1` version string and also need the same change I have modified them in the same way and produced files with a `-2` end to the name.

This should close #136.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>