### PR TITLE
adding connecting string option for env:connect(sourcename) in luasql.odbc

### DIFF
--- a/src/ls_odbc.c
+++ b/src/ls_odbc.c
@@ -1101,8 +1101,22 @@ static int env_connect (lua_State *L) {
 	}
 
 	/* tries to connect handle */
-	ret = SQLConnect (hdbc, sourcename, SQL_NTS,
-		username, SQL_NTS, password, SQL_NTS);
+	if (is_connection_string) {
+		ret = SQLDriverConnect(
+			hdbc,
+			NULL, /* window handle */
+			sourcename,
+			SQL_NTS,
+			NULL, /* output connection string buffer */
+			0, /* sizeof output buffer */
+			NULL, /* actual length of output string buffer */
+			SQL_DRIVER_NOPROMPT
+		);
+	} else {
+		ret = SQLConnect (hdbc, sourcename, SQL_NTS, 
+			username, SQL_NTS, password, SQL_NTS);
+	}
+	
 	if (error(ret)) {
 		ret = fail(L, hDBC, hdbc);
 		SQLFreeHandle(hDBC, hdbc);


### PR DESCRIPTION
In function `env:connect(sourcename[,username[,password]])` in `luasql.odbc`, this enables `sourcename` argument the option to be a `connection_string`, where the expected format is like:

`"Driver={SQL Server Native Client 11.0};Server=localhost;Database=EDB;UID=user;PWD=password"`

It now checks to see if the sourcename string contains '=' and tries to connect with it as a `connection_string` if it does. Otherwise, it defaults back existing code to handle DSN.