### PR TITLE
Add: 2.7.1 rockspec files and add one for luasql-odbc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Duplicate this value in the last bit of ./src/luasql.c
 V= 2.7.1
 CONFIG= ./config
 

--- a/rockspec/luasql-firebird-2.7.1-1.rockspec
+++ b/rockspec/luasql-firebird-2.7.1-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-Firebird"
+version = "2.7.1-1"
+source = {
+  url = "git+https://github.com/lunarmodules/luasql.git",
+  branch = "2.7.1",
+}
+description = {
+   summary = "Database connectivity for Lua (Firebird driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "https://lunarmodules.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   FB = {
+      header = "ibase.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.firebird"] = {
+       sources = { "src/luasql.c", "src/ls_firebird.c" },
+       libraries = { "fbclient" },
+       incdirs = { "$(FB_INCDIR)" },
+       libdirs = { "$(FB_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-mysql-2.7.1-1.rockspec
+++ b/rockspec/luasql-mysql-2.7.1-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-MySQL"
+version = "2.7.1-1"
+source = {
+  url = "git+https://github.com/lunarmodules/luasql.git",
+  branch = "2.7.1",
+}
+description = {
+   summary = "Database connectivity for Lua (MySQL driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "https://lunarmodules.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   MYSQL = {
+      header = "mysql.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.mysql"] = {
+       sources = { "src/luasql.c", "src/ls_mysql.c" },
+       libraries = { "mysqlclient" },
+       incdirs = { "$(MYSQL_INCDIR)" },
+       libdirs = { "$(MYSQL_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-odbc-2.7.1-1.rockspec
+++ b/rockspec/luasql-odbc-2.7.1-1.rockspec
@@ -1,0 +1,49 @@
+package = "LuaSQL-ODBC"
+version = "2.7.1-1"
+source = {
+  url = "git+https://github.com/lunarmodules/luasql.git",
+  branch = "2.7.1",
+}
+description = {
+   summary = "Database connectivity for Lua (ODBC driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "https://lunarmodules.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ODBC = {
+      header = "sql.h"
+   }
+}
+build = {
+   type = "builtin",
+   platforms = {
+     windows = {
+       modules = {
+         ["luasql.odbc"] = {
+           sources = { "src/luasql.c", "src/ls_odbc.c" },
+           incdirs = { "$(ODBC_INCDIR)" },
+           libdirs = { "$(ODBC_LIBDIR)" },
+           libraries = { "odbc32" }
+         }
+       }
+     },
+     unix = {
+       modules = {
+         ["luasql.odbc"] = {
+           sources = { "src/luasql.c", "src/ls_odbc.c" },
+           incdirs = { "$(ODBC_INCDIR)" },
+           libdirs = { "$(ODBC_LIBDIR)" },
+           libraries = { "odbc" }
+         }
+       }
+     }
+   }
+}

--- a/rockspec/luasql-postgres-2.7.1-1.rockspec
+++ b/rockspec/luasql-postgres-2.7.1-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-Postgres"
+version = "2.7.1-1"
+source = {
+  url = "git+https://github.com/lunarmodules/luasql.git",
+  branch = "2.7.1",
+}
+description = {
+   summary = "Database connectivity for Lua (Postgres driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "https://lunarmodules.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   PGSQL = {
+      header = "libpq-fe.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.postgres"] = {
+       sources = { "src/luasql.c", "src/ls_postgres.c" },
+       libraries = { "pq" },
+       incdirs = { "$(PGSQL_INCDIR)" },
+       libdirs = { "$(PGSQL_LIBDIR)" }
+     }
+   }
+}

--- a/rockspec/luasql-sqlite3-2.7.1-1.rockspec
+++ b/rockspec/luasql-sqlite3-2.7.1-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaSQL-SQLite3"
+version = "2.7.1-1"
+source = {
+  url = "git+https://github.com/lunarmodules/luasql.git",
+  branch = "2.7.1",
+}
+description = {
+   summary = "Database connectivity for Lua (SQLite3 driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "https://lunarmodules.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   SQLITE = {
+      header = "sqlite3.h"
+   }
+}
+build = {
+   type = "builtin",
+   modules = {
+     ["luasql.sqlite3"] = {
+       sources = { "src/luasql.c", "src/ls_sqlite3.c" },
+       libraries = { "sqlite3" },
+       incdirs = { "$(SQLITE_INCDIR)" },
+       libdirs = { "$(SQLITE_LIBDIR)" }
+     }
+   }
+}

--- a/src/luasql.c
+++ b/src/luasql.c
@@ -128,6 +128,11 @@ LUASQL_API void luasql_set_info (lua_State *L) {
 	lua_pushliteral (L, "LuaSQL is a simple interface from Lua to a DBMS");
 	lua_settable (L, -3);
 	lua_pushliteral (L, "_VERSION");
+#if ! defined(LUASQL_VERSION_NUMBER)
+#warning "LUASQL_VERSION_NUMBER is not defined, assuming value of 2.7.1!"
+	lua_pushliteral (L, "LuaSQL 2.7.1 (for "LUA_VERSION")");
+#else
 	lua_pushliteral (L, "LuaSQL "LUASQL_VERSION_NUMBER" (for "LUA_VERSION")");
+#endif
 	lua_settable (L, -3);
 }


### PR DESCRIPTION
Also works around a problem with commit 071678f5a3a3997e7040828b5ab6e299c8d58f57 as it just doesn't work for some compiler/OS combinations (e.g. clang 21 in Windows MSYS2+Mingw-w64 environment).

I could not verify a successful build with the following types so have not updated them:
* `duckdb` - a couple of warnings about incompatible pointer types, I do not know enough to say whether the resulting `luasql-duckdb.so` is safe to use.
* `oci8` - not available - there may be scope for a replacement by: https://github.com/SOCI/soci
* `sqlite` - not available (only the later `sqlite3` one is) in my development environment.

Also:
* `sqlite3` requires an additional `MYSQL_INCDIR=${MINGW_PREFIX}/include/mysql` argument to find the appropriate MSYS2+Mingw-w64 environment.