### PR TITLE
dev rockspec and CI for LuaSQL ODBC driver

### DIFF
--- a/.github/workflows/test-odbc.yml
+++ b/.github/workflows/test-odbc.yml
@@ -1,0 +1,94 @@
+name: Test ODBC
+
+on: [push, pull_request]
+
+jobs:
+  test-unix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        lua-version: ["5.1", "5.2", "5.3", "5.4", "5.5", "luajit", "openresty"]
+        os: ["ubuntu-latest", "macos-latest"]
+
+    env:
+      UNIX_ODBC_VERSION: 2.3.14
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: luau-project/setup-lua@740668c632803d06039deb1c6e7c9293a26fa8e7 # v1.0.9
+      with:
+        lua-version: ${{ matrix.lua-version }}
+
+    - name: Show Lua and LuaRocks version
+      run: |
+        lua -v
+        luarocks --version
+
+    - name: Download Unix ODBC
+      run: |
+        cd "${{ runner.temp }}"
+        curl -L -O \
+          "https://github.com/lurcher/unixODBC/releases/download/v${{ env.UNIX_ODBC_VERSION }}/unixODBC-${{ env.UNIX_ODBC_VERSION }}.tar.gz"
+
+    - name: Extract Unix ODBC
+      run: tar -C "${{ runner.temp }}" -xf "${{ runner.temp }}/unixODBC-${{ env.UNIX_ODBC_VERSION }}.tar.gz"
+
+    - name: Configure, build and install Unix ODBC
+      run: |
+        cd "${{ runner.temp }}"
+        mkdir "build-unixODBC-${{ env.UNIX_ODBC_VERSION }}"
+        cd "build-unixODBC-${{ env.UNIX_ODBC_VERSION }}"
+
+        ../unixODBC-${{ env.UNIX_ODBC_VERSION }}/configure --prefix=/usr/local && \
+        make && \
+        sudo make install
+
+    - name: Build and install luasql-odbc
+      run: luarocks make "rockspec/luasql-odbc-dev-1.rockspec"
+
+  test-windows:
+    runs-on: "windows-latest"
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      fail-fast: false
+      matrix:
+        lua-version: ["5.1", "5.2", "5.3", "5.4", "5.5", "luajit", "openresty"]
+        toolchain: ["msvc", "gcc"]
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      if: ${{ matrix.toolchain == 'msvc' }}
+
+    - uses: luau-project/setup-lua@740668c632803d06039deb1c6e7c9293a26fa8e7 # v1.0.9
+      with:
+        lua-version: ${{ matrix.lua-version }}
+
+    - name: Show Lua and LuaRocks version
+      run: |
+        lua -v
+        luarocks --version
+
+    # For the latest MSVC on Windows, we need to feed LuaRocks
+    # the path to the directory containing 'sql.h'.
+    # At the moment, 'sql.h' can be found at:
+    # Windows SDK dir (e.g.: C:\Program Files (x86)\Windows Kits\10\) +
+    # the include subdir (e.g.: include) +
+    # Windows SDK version subdir (e.g.: 10.0.26100.0\) +
+    # the um subdir (e.g.: um)
+    #
+    # In short, on recent MSVC, 'sql.h' can be found at:
+    # C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\um
+    #
+    - name: Build and install luasql-odbc (MSVC)
+      if: ${{ matrix.toolchain == 'msvc' }}
+      run: luarocks make "rockspec\luasql-odbc-dev-1.rockspec" "ODBC_INCDIR=%WindowsSdkDir%include\%WindowsSDKVersion%um"
+
+    - name: Build and install luasql-odbc (MinGW-w64)
+      if: ${{ matrix.toolchain != 'msvc' }}
+      run: luarocks make "rockspec\luasql-odbc-dev-1.rockspec"

--- a/rockspec/luasql-odbc-dev-1.rockspec
+++ b/rockspec/luasql-odbc-dev-1.rockspec
@@ -1,0 +1,51 @@
+package = "LuaSQL-ODBC"
+version = "dev-1"
+source = {
+  url = "git+https://github.com/lunarmodules/luasql.git",
+  branch = "master",
+}
+description = {
+   summary = "Database connectivity for Lua (ODBC driver)",
+   detailed = [[
+      LuaSQL is a simple interface from Lua to a DBMS. It enables a
+      Lua program to connect to databases, execute arbitrary SQL statements
+      and retrieve results in a row-by-row cursor fashion.
+   ]],
+   license = "MIT/X11",
+   homepage = "https://lunarmodules.github.io/luasql/"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ODBC = {
+      header = "sql.h"
+   }
+}
+build = {
+   type = "builtin",
+   platforms = {
+     windows = { 
+       modules = {
+         ["luasql.odbc"] = {
+           sources = { "src/luasql.c", "src/ls_odbc.c" },  
+           defines = { "LUASQL_VERSION_NUMBER=\"" .. source.branch .. "\"" },
+           incdirs = { "$(ODBC_INCDIR)" },
+           libdirs = { "$(ODBC_LIBDIR)" },
+           libraries = { "odbc32" }
+         }
+       }
+     },
+     unix = { 
+       modules = {
+         ["luasql.odbc"] = {
+           sources = { "src/luasql.c", "src/ls_odbc.c" },  
+           defines = { "LUASQL_VERSION_NUMBER=\"" .. source.branch .. "\"" },
+           incdirs = { "$(ODBC_INCDIR)" },
+           libdirs = { "$(ODBC_LIBDIR)" },
+           libraries = { "odbc" }
+         }
+       }
+     }
+   }
+}


### PR DESCRIPTION
dev rockspec + CI for the ODBC driver

> [!NOTE]
> 
> Since you usually have a `source.branch` as the tag version, I used it rather than the `version` field, because the version field usually contains the `-1` suffix (rockspec revision)

> [!IMPORTANT]
> 
> Whenever you want a new release, just copy the `dev` rockspec, changing "version" and "source.branch" like the previous releases (or better yet, `sed` version and source.branch it).

## PS

I am a bit short on time, so I'll be posting CI for the other drivers in the upcoming days / weeks.