### PR TITLE
Async I/O support for PostgreSQL, MySQL/MariaDB, and SQLite3 drivers #200

### DIFF
--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -482,6 +482,67 @@ static int escape_string (lua_State *L) {
 }
 
 /*
+** Asynchronous execution methods
+*/
+static int conn_getfd (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	int fd = mysql_get_socket(conn->my_conn);
+	if (fd < 0) return luasql_failmsg(L, "invalid socket descriptor", NULL);
+	lua_pushinteger(L, fd);
+	return 1;
+}
+
+static int conn_send_query (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	size_t st_len;
+	const char *statement = luaL_checklstring (L, 2, &st_len);
+	int status, ret;
+#ifdef MARIADB_PACKAGE_VERSION
+	status = mysql_real_query_start(&ret, conn->my_conn, statement, st_len);
+#else
+	/* Fallback for standard MySQL without async support */
+	ret = mysql_real_query(conn->my_conn, statement, st_len);
+	status = 0;
+#endif
+	lua_pushinteger(L, status);
+	lua_pushinteger(L, ret);
+	return 2;
+}
+
+static int conn_query_cont (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	int status = luaL_checkinteger(L, 2);
+	int ret;
+#ifdef MARIADB_PACKAGE_VERSION
+	status = mysql_real_query_cont(&ret, conn->my_conn, status);
+#else
+	ret = 0;
+	status = 0;
+#endif
+	lua_pushinteger(L, status);
+	lua_pushinteger(L, ret);
+	return 2;
+}
+
+static int conn_get_result (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	MYSQL_RES *res = mysql_store_result(conn->my_conn);
+	unsigned int num_cols = mysql_field_count(conn->my_conn);
+
+	if (res) { /* tuples returned */
+		return create_cursor (L, conn->my_conn, 1, res, num_cols);
+	}
+	else {
+		if(num_cols == 0) { /* no tuples returned */
+			lua_pushnumber(L, mysql_affected_rows(conn->my_conn));
+			return 1;
+		}
+		else
+			return luasql_failmsg(L, "error retrieving result. MySQL: ", mysql_error(conn->my_conn));
+	}
+}
+
+/*
 ** Execute an SQL statement.
 ** Return a Cursor object if the statement is a query, otherwise
 ** return the number of tuples affected by the statement.
@@ -599,6 +660,9 @@ static int env_connect (lua_State *L) {
 		return luasql_faildirect(L, "error connecting: Out of memory.");
 
 	mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, "client-lua");	
+#ifdef MARIADB_PACKAGE_VERSION
+	mysql_options(conn, MYSQL_OPT_NONBLOCK, 0);
+#endif
 	
 	if (!mysql_real_connect(conn, host, username, password,
 		sourcename, port, unix_socket, client_flag))
@@ -665,6 +729,10 @@ static void create_metatables (lua_State *L) {
 		{"rollback", conn_rollback},
 		{"setautocommit", conn_setautocommit},
 		{"getlastautoid", conn_getlastautoid},
+		{"getfd",         conn_getfd},
+		{"send_query",    conn_send_query},
+		{"query_cont",    conn_query_cont},
+		{"get_result",    conn_get_result},
 		{NULL, NULL},
     };
     struct luaL_Reg cursor_methods[] = {

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -534,6 +534,8 @@ static int conn_get_result (lua_State *L) {
 	}
 	else {
 		if(num_cols == 0) { /* no tuples returned */
+			if (mysql_errno(conn->my_conn))
+				return luasql_failmsg(L, "error retrieving result. MySQL: ", mysql_error(conn->my_conn));
 			lua_pushnumber(L, mysql_affected_rows(conn->my_conn));
 			return 1;
 		}

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -509,7 +509,7 @@ static int conn_send_query (lua_State *L) {
 	return 2;
 }
 
-static int conn_query_cont (lua_State *L) {
+static int conn_poll (lua_State *L) {
 	conn_data *conn = getconnection (L);
 	int status = luaL_checkinteger(L, 2);
 	int ret;
@@ -519,8 +519,8 @@ static int conn_query_cont (lua_State *L) {
 	ret = 0;
 	status = 0;
 #endif
+	lua_pushboolean(L, status != 0);
 	lua_pushinteger(L, status);
-	lua_pushinteger(L, ret);
 	return 2;
 }
 
@@ -731,7 +731,7 @@ static void create_metatables (lua_State *L) {
 		{"getlastautoid", conn_getlastautoid},
 		{"getfd",         conn_getfd},
 		{"send_query",    conn_send_query},
-		{"query_cont",    conn_query_cont},
+		{"poll",          conn_poll},
 		{"get_result",    conn_get_result},
 		{NULL, NULL},
     };

--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -497,7 +497,7 @@ static int conn_send_query (lua_State *L) {
 	size_t st_len;
 	const char *statement = luaL_checklstring (L, 2, &st_len);
 	int status, ret;
-#ifdef MARIADB_PACKAGE_VERSION
+#ifdef MYSQL_OPT_NONBLOCK
 	status = mysql_real_query_start(&ret, conn->my_conn, statement, st_len);
 #else
 	/* Fallback for standard MySQL without async support */
@@ -513,7 +513,7 @@ static int conn_poll (lua_State *L) {
 	conn_data *conn = getconnection (L);
 	int status = luaL_checkinteger(L, 2);
 	int ret;
-#ifdef MARIADB_PACKAGE_VERSION
+#ifdef MYSQL_OPT_NONBLOCK
 	status = mysql_real_query_cont(&ret, conn->my_conn, status);
 #else
 	ret = 0;

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -373,17 +373,11 @@ static int conn_send_query (lua_State *L) {
 	return 2;
 }
 
-static int conn_consume_input (lua_State *L) {
+static int conn_poll (lua_State *L) {
 	conn_data *conn = getconnection (L);
 	if (PQconsumeInput(conn->pg_conn) == 0) {
-		return luasql_failmsg(L, "error consuming input. PostgreSQL: ", PQerrorMessage(conn->pg_conn));
+		return luasql_failmsg(L, "error polling input. PostgreSQL: ", PQerrorMessage(conn->pg_conn));
 	}
-	lua_pushboolean(L, 1);
-	return 1;
-}
-
-static int conn_is_busy (lua_State *L) {
-	conn_data *conn = getconnection (L);
 	lua_pushboolean(L, PQisBusy(conn->pg_conn));
 	return 1;
 }
@@ -660,8 +654,7 @@ static void create_metatables (lua_State *L) {
 		{"setautocommit", conn_setautocommit},
 		{"getfd",         conn_getfd},
 		{"send_query",    conn_send_query},
-		{"consume_input", conn_consume_input},
-		{"is_busy",       conn_is_busy},
+		{"poll",          conn_poll},
 		{"get_result",    conn_get_result},
 		{NULL, NULL},
 	};

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -354,11 +354,23 @@ static int conn_getfd (lua_State *L) {
 static int conn_send_query (lua_State *L) {
 	conn_data *conn = getconnection (L);
 	const char *statement = luaL_checkstring (L, 2);
+	
+	/* Ensure we are in non-blocking mode before sending */
+	PQsetnonblocking(conn->pg_conn, 1);
+	
 	if (PQsendQuery(conn->pg_conn, statement) == 0) {
 		return luasql_failmsg(L, "error sending query. PostgreSQL: ", PQerrorMessage(conn->pg_conn));
 	}
+	
+	/* Flush outgoing buffer. 0 = success, 1 = still flushing, -1 = error */
+	int flush_res = PQflush(conn->pg_conn);
+	if (flush_res == -1) {
+		return luasql_failmsg(L, "error flushing query. PostgreSQL: ", PQerrorMessage(conn->pg_conn));
+	}
+	
 	lua_pushboolean(L, 1);
-	return 1;
+	lua_pushinteger(L, flush_res); /* Return if it's still flushing */
+	return 2;
 }
 
 static int conn_consume_input (lua_State *L) {
@@ -472,6 +484,10 @@ static int conn_escape (lua_State *L) {
 static int conn_execute (lua_State *L) {
 	conn_data *conn = getconnection (L);
 	const char *statement = luaL_checkstring (L, 2);
+	
+	/* Force blocking mode for the classic execute method to maintain compatibility */
+	PQsetnonblocking(conn->pg_conn, 0);
+	
 	PGresult *res = PQexec(conn->pg_conn, statement);
 	if (res && PQresultStatus(res)==PGRES_COMMAND_OK) {
 		/* no tuples returned */
@@ -546,6 +562,9 @@ static int conn_setautocommit (lua_State *L) {
 static int create_connection (lua_State *L, int env, PGconn *const pg_conn) {
 	conn_data *conn = (conn_data *)LUASQL_NEWUD(L, sizeof(conn_data));
 	luasql_setmeta (L, LUASQL_CONNECTION_PG);
+
+	/* Default to non-blocking mode for improved responsiveness */
+	PQsetnonblocking(pg_conn, 1);
 
 	/* fill in structure */
 	conn->closed = 0;

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -340,6 +340,63 @@ static int conn_gc (lua_State *L) {
 	return 0;
 }
 
+/*
+** Asynchronous execution methods
+*/
+static int conn_getfd (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	int fd = PQsocket(conn->pg_conn);
+	if (fd < 0) return luasql_failmsg(L, "invalid socket descriptor", NULL);
+	lua_pushinteger(L, fd);
+	return 1;
+}
+
+static int conn_send_query (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	const char *statement = luaL_checkstring (L, 2);
+	if (PQsendQuery(conn->pg_conn, statement) == 0) {
+		return luasql_failmsg(L, "error sending query. PostgreSQL: ", PQerrorMessage(conn->pg_conn));
+	}
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
+static int conn_consume_input (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	if (PQconsumeInput(conn->pg_conn) == 0) {
+		return luasql_failmsg(L, "error consuming input. PostgreSQL: ", PQerrorMessage(conn->pg_conn));
+	}
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
+static int conn_is_busy (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	lua_pushboolean(L, PQisBusy(conn->pg_conn));
+	return 1;
+}
+
+static int conn_get_result (lua_State *L) {
+	conn_data *conn = getconnection (L);
+	PGresult *res = PQgetResult(conn->pg_conn);
+	if (!res) {
+		lua_pushnil(L);
+		return 1;
+	}
+	if (PQresultStatus(res) == PGRES_COMMAND_OK) {
+		lua_pushnumber(L, atof(PQcmdTuples(res)));
+		PQclear (res);
+		return 1;
+	}
+	else if (PQresultStatus(res) == PGRES_TUPLES_OK) {
+		return create_cursor (L, 1, res);
+	}
+	else {
+		const char *err = PQresultErrorMessage(res);
+		PQclear (res);
+		return luasql_failmsg(L, "error retrieving result. PostgreSQL: ", err);
+	}
+}
 
 /*
 ** Closes the connection on top of the stack.

--- a/src/ls_postgres.c
+++ b/src/ls_postgres.c
@@ -639,6 +639,11 @@ static void create_metatables (lua_State *L) {
 		{"commit",        conn_commit},
 		{"rollback",      conn_rollback},
 		{"setautocommit", conn_setautocommit},
+		{"getfd",         conn_getfd},
+		{"send_query",    conn_send_query},
+		{"consume_input", conn_consume_input},
+		{"is_busy",       conn_is_busy},
+		{"get_result",    conn_get_result},
 		{NULL, NULL},
 	};
 	struct luaL_Reg cursor_methods[] = {

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -546,12 +546,7 @@ static int conn_send_query (lua_State *L) {
   return 1;
 }
 
-static int conn_consume_input (lua_State *L) {
-  lua_pushboolean(L, 1);
-  return 1;
-}
-
-static int conn_is_busy (lua_State *L) {
+static int conn_poll (lua_State *L) {
   lua_pushboolean(L, 0);
   return 1;
 }
@@ -892,8 +887,7 @@ static void create_metatables (lua_State *L)
     {"getlastautoid", conn_getlastautoid},
     {"getfd",         conn_getfd},
     {"send_query",    conn_send_query},
-    {"consume_input", conn_consume_input},
-    {"is_busy",       conn_is_busy},
+    {"poll",          conn_poll},
     {"get_result",    conn_get_result},
     {NULL, NULL},
   };

--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -35,6 +35,7 @@ typedef struct
   short        auto_commit;        /* 0 for manual commit */
   unsigned int cur_counter;
   sqlite3      *sql_conn;
+  sqlite3_stmt *pending_vm;        /* for async-like support */
 } conn_data;
 
 
@@ -332,6 +333,7 @@ static int conn_gc(lua_State *L)
       /* Nullify structure fields. */
       conn->closed = 1;
       luaL_unref(L, LUA_REGISTRYINDEX, conn->env);
+      if (conn->pending_vm) sqlite3_finalize(conn->pending_vm);
       sqlite3_close(conn->sql_conn);
     }
   return 0;
@@ -361,6 +363,7 @@ static int conn_close(lua_State *L)
 
   conn->closed = 1;
   luaL_unref(L, LUA_REGISTRYINDEX, conn->env);
+  if (conn->pending_vm) sqlite3_finalize(conn->pending_vm);
   sqlite3_close(conn->sql_conn);
 
   lua_pushboolean(L, 1);
@@ -483,6 +486,102 @@ static int raw_readparams_table(lua_State *L, sqlite3_stmt *vm, int arg)
   }
 
   return rc;
+}
+
+/*
+** Asynchronous execution methods
+*/
+static int conn_getfd (lua_State *L) {
+  conn_data *conn = getconnection (L);
+  int fd = -1;
+  void *pFile = NULL;
+  int res = sqlite3_file_control(conn->sql_conn, "main", SQLITE_FCNTL_FILE_POINTER, &pFile);
+  if (res == SQLITE_OK && pFile) {
+    /* Trick to get the FD from unixFile structure */
+    fd = *((int*)((char*)pFile + 2 * sizeof(void*)));
+  }
+  /* Fallback: return stdin if we cannot get the real FD, or it's a memory DB */
+  if (fd < 0) fd = 0;
+  lua_pushinteger(L, fd);
+  return 1;
+}
+
+static int conn_send_query (lua_State *L) {
+  conn_data *conn = getconnection (L);
+  const char *statement = luaL_checkstring (L, 2);
+  sqlite3_stmt *vm;
+  const char *tail;
+  int res;
+
+  if (conn->pending_vm) {
+    sqlite3_finalize(conn->pending_vm);
+    conn->pending_vm = NULL;
+  }
+
+#if SQLITE_VERSION_NUMBER > 3006013
+  res = sqlite3_prepare_v2(conn->sql_conn, statement, -1, &vm, &tail);
+#else
+  res = sqlite3_prepare(conn->sql_conn, statement, -1, &vm, &tail);
+#endif
+  if (res != SQLITE_OK) {
+    return luasql_faildirect(L, sqlite3_errmsg(conn->sql_conn));
+  }
+
+  /* Bind parameters (if any) */
+  int ltop = lua_gettop(L);
+  if (ltop > 2) {
+    if (ltop == 3 && lua_type(L, 3) == LUA_TTABLE) {
+      res = raw_readparams_table(L, vm, 3);
+    } else if (ltop >= 3) {
+      res = raw_readparams_args(L, vm, 3, ltop);
+    }
+    if (res) {
+      sqlite3_finalize(vm);
+      return res;
+    }
+  }
+
+  conn->pending_vm = vm;
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+static int conn_consume_input (lua_State *L) {
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+static int conn_is_busy (lua_State *L) {
+  lua_pushboolean(L, 0);
+  return 1;
+}
+
+static int conn_get_result (lua_State *L) {
+  conn_data *conn = getconnection (L);
+  if (!conn->pending_vm) {
+    lua_pushnil(L);
+    return 1;
+  }
+  
+  sqlite3_stmt *vm = conn->pending_vm;
+  conn->pending_vm = NULL;
+  
+  int res = sqlite3_step(vm);
+  int numcols = sqlite3_column_count(vm);
+
+  if ((res == SQLITE_ROW) || ((res == SQLITE_DONE) && numcols)) {
+    return create_cursor(L, 1, conn, vm, numcols);
+  }
+
+  if (res == SQLITE_DONE) {
+    sqlite3_finalize(vm);
+    lua_pushnumber(L, sqlite3_changes(conn->sql_conn));
+    return 1;
+  }
+
+  const char *errmsg = sqlite3_errmsg(conn->sql_conn);
+  sqlite3_finalize(vm);
+  return luasql_faildirect(L, errmsg);
 }
 
 /*
@@ -660,6 +759,7 @@ static int create_connection(lua_State *L, int env, sqlite3 *sql_conn)
   conn->auto_commit = 1;
   conn->sql_conn = sql_conn;
   conn->cur_counter = 0;
+  conn->pending_vm = NULL;
   lua_pushvalue (L, env);
   conn->env = luaL_ref (L, LUA_REGISTRYINDEX);
   return 1;
@@ -790,6 +890,11 @@ static void create_metatables (lua_State *L)
     {"rollback", conn_rollback},
     {"setautocommit", conn_setautocommit},
     {"getlastautoid", conn_getlastautoid},
+    {"getfd",         conn_getfd},
+    {"send_query",    conn_send_query},
+    {"consume_input", conn_consume_input},
+    {"is_busy",       conn_is_busy},
+    {"get_result",    conn_get_result},
     {NULL, NULL},
   };
   struct luaL_Reg cursor_methods[] = {

--- a/tests/performance_async.lua
+++ b/tests/performance_async.lua
@@ -2,7 +2,7 @@
 -- LuaSQL Performance and Async Test Suite
 ---------------------------------------------------------------------
 -- This script benchmarks LuaSQL drivers for throughput and latency.
--- It supports Sync and Async (PostgreSQL only) operations.
+-- It supports Sync and Async (PostgreSQL and MySQL) operations.
 --
 -- Environment Variables for Configuration:
 --   DB_HOST: Database host (default: localhost)
@@ -16,7 +16,7 @@
 --    DB_HOST=localhost DB_NAME=postgres DB_USER=postgres DB_PASS=123456 \
 --    lua tests/performance_async.lua postgres
 --
--- 2. MySQL / MariaDB:
+-- 2. MySQL / MariaDB (with Async support):
 --    DB_HOST=localhost DB_NAME=luasql_test DB_USER=luasql DB_PASS=luasql \
 --    lua tests/performance_async.lua mysql
 --
@@ -51,7 +51,11 @@ end
 
 local conn = assert(get_connection())
 conn:execute("DROP TABLE IF EXISTS perf_test")
-conn:execute("CREATE TABLE perf_test (id INTEGER, val VARCHAR(255))")
+if driver_name == "mysql" then
+    conn:execute("CREATE TABLE perf_test (id INTEGER, val VARCHAR(255)) ENGINE=InnoDB")
+else
+    conn:execute("CREATE TABLE perf_test (id INTEGER, val VARCHAR(255))")
+end
 
 print(string.format("Starting performance test for %s (%d iterations)...", driver_name, ITERATIONS))
 
@@ -65,9 +69,9 @@ local end_time = os.clock()
 local sync_duration = end_time - start_time
 print(string.format("  Sync INSERT: %.4f seconds (%.2f op/s)", sync_duration, ITERATIONS / sync_duration))
 
--- 2. Async/Batch Performance (PostgreSQL specific)
+-- 2. Async/Batch Performance (PostgreSQL and MySQL specific)
 if driver_name == "postgres" and conn.send_query and conn.get_result then
-    print(string.format("  Running Async INSERT test (batch size: %d)...", ASYNC_BATCH))
+    print(string.format("  Running Postgres Async INSERT test (batch size: %d)...", ASYNC_BATCH))
     conn:execute("DELETE FROM perf_test")
     
     start_time = os.clock()
@@ -84,6 +88,45 @@ if driver_name == "postgres" and conn.send_query and conn.get_result then
                     if type(res) == "userdata" then res:close() end
                     res = conn:get_result()
                 end
+            end
+        end
+    end
+    end_time = os.clock()
+    local async_duration = end_time - start_time
+    print(string.format("  Async INSERT: %.4f seconds (%.2f op/s)", async_duration, ITERATIONS / async_duration))
+    print(string.format("  Async is %.2fx faster than Sync", sync_duration / async_duration))
+
+elseif driver_name == "mysql" and conn.send_query and conn.get_result then
+    print(string.format("  Running MySQL Async INSERT test (batch size: %d)...", ASYNC_BATCH))
+    conn:execute("DELETE FROM perf_test")
+    
+    start_time = os.clock()
+    for i = 1, ITERATIONS, ASYNC_BATCH do
+        local batch_handles = {}
+        for j = 0, ASYNC_BATCH - 1 do
+            if (i+j) <= ITERATIONS then
+                local status, ret = conn:send_query(string.format("INSERT INTO perf_test VALUES (%d, 'async_value_%d')", i+j, i+j))
+                if status ~= 0 then
+                    -- If status is not 0, we need to poll
+                    table.insert(batch_handles, status)
+                end
+            end
+        end
+        
+        -- Poll remaining results (MySQL async is per-query, limited by single connection)
+        -- Note: On a single connection, MySQL async still serializes, but allows non-blocking wait.
+        for _, status in ipairs(batch_handles) do
+            local busy, new_status = conn:poll(status)
+            while busy do
+                busy, new_status = conn:poll(new_status)
+            end
+        end
+        
+        -- Consume results
+        for j = 0, ASYNC_BATCH - 1 do
+            if (i+j) <= ITERATIONS then
+                local res = conn:get_result()
+                if type(res) == "userdata" then res:close() end
             end
         end
     end

--- a/tests/performance_async.lua
+++ b/tests/performance_async.lua
@@ -1,0 +1,114 @@
+---------------------------------------------------------------------
+-- LuaSQL Performance and Async Test Suite
+---------------------------------------------------------------------
+-- This script benchmarks LuaSQL drivers for throughput and latency.
+-- It supports Sync and Async (PostgreSQL only) operations.
+--
+-- Environment Variables for Configuration:
+--   DB_HOST: Database host (default: localhost)
+--   DB_NAME: Database name or schema (default: luasql_test)
+--   DB_USER: Database username (default: luasql)
+--   DB_PASS: Database password (default: luasql)
+--
+-- How to run for different databases:
+--
+-- 1. PostgreSQL (with Async support):
+--    DB_HOST=localhost DB_NAME=postgres DB_USER=postgres DB_PASS=123456 \
+--    lua tests/performance_async.lua postgres
+--
+-- 2. MySQL / MariaDB:
+--    DB_HOST=localhost DB_NAME=luasql_test DB_USER=luasql DB_PASS=luasql \
+--    lua tests/performance_async.lua mysql
+--
+-- 3. SQLite3 (In-memory, no variables needed):
+--    lua tests/performance_async.lua sqlite3
+---------------------------------------------------------------------
+
+local driver_name = arg[1] or "sqlite3"
+local luasql = require("luasql."..driver_name)
+local env = luasql[driver_name]()
+
+-- Configuration
+local ITERATIONS = 1000
+local ASYNC_BATCH = 50
+
+-- Helper to establish connection based on driver and environment variables
+local function get_connection()
+    local host = os.getenv("DB_HOST") or "localhost"
+    local dbname = os.getenv("DB_NAME") or "luasql_test"
+    local user = os.getenv("DB_USER") or "luasql"
+    local pass = os.getenv("DB_PASS") or "luasql"
+
+    if driver_name == "sqlite3" then
+        return env:connect(":memory:")
+    elseif driver_name == "postgres" then
+        local conn_str = string.format("host=%s dbname=%s user=%s password=%s", host, dbname, user, pass)
+        return env:connect(conn_str)
+    elseif driver_name == "mysql" then
+        return env:connect(dbname, user, pass, host)
+    end
+end
+
+local conn = assert(get_connection())
+conn:execute("DROP TABLE IF EXISTS perf_test")
+conn:execute("CREATE TABLE perf_test (id INTEGER, val VARCHAR(255))")
+
+print(string.format("Starting performance test for %s (%d iterations)...", driver_name, ITERATIONS))
+
+-- 1. Sync Performance (Baseline)
+print("  Running Sync INSERT test...")
+local start_time = os.clock()
+for i = 1, ITERATIONS do
+    conn:execute(string.format("INSERT INTO perf_test VALUES (%d, 'sync_value_%d')", i, i))
+end
+local end_time = os.clock()
+local sync_duration = end_time - start_time
+print(string.format("  Sync INSERT: %.4f seconds (%.2f op/s)", sync_duration, ITERATIONS / sync_duration))
+
+-- 2. Async/Batch Performance (PostgreSQL specific)
+if driver_name == "postgres" and conn.send_query and conn.get_result then
+    print(string.format("  Running Async INSERT test (batch size: %d)...", ASYNC_BATCH))
+    conn:execute("DELETE FROM perf_test")
+    
+    start_time = os.clock()
+    for i = 1, ITERATIONS, ASYNC_BATCH do
+        for j = 0, ASYNC_BATCH - 1 do
+            if (i+j) <= ITERATIONS then
+                conn:send_query(string.format("INSERT INTO perf_test VALUES (%d, 'async_value_%d')", i+j, i+j))
+            end
+        end
+        for j = 0, ASYNC_BATCH - 1 do
+            if (i+j) <= ITERATIONS then
+                local res = conn:get_result()
+                while res do
+                    if type(res) == "userdata" then res:close() end
+                    res = conn:get_result()
+                end
+            end
+        end
+    end
+    end_time = os.clock()
+    local async_duration = end_time - start_time
+    print(string.format("  Async INSERT: %.4f seconds (%.2f op/s)", async_duration, ITERATIONS / async_duration))
+    print(string.format("  Async is %.2fx faster than Sync", sync_duration / async_duration))
+else
+    print("  Native Async (send_query/get_result) not available for this driver.")
+end
+
+-- 3. Read Performance
+print("  Running SELECT test...")
+start_time = os.clock()
+local cur = conn:execute("SELECT * FROM perf_test")
+local row = cur:fetch({}, "a")
+local count = 0
+while row do
+    count = count + 1
+    row = cur:fetch(row, "a")
+end
+cur:close()
+end_time = os.clock()
+print(string.format("  Sync SELECT (%d rows): %.4f seconds", count, end_time - start_time))
+
+conn:close()
+env:close()
+print("Done.\n")


### PR DESCRIPTION
The goal is to allow LuaSQL to operate efficiently in event-driven environments (such as those built with coroutine schedulers or event loops), avoiding blocking database operations.

The implementation introduces a unified non-blocking query lifecycle across drivers with the following API:

`conn:send_query(sql)` — initiates a non-blocking query

`conn:poll([last_status])` — advances the internal state machine to completion

`conn:get_result()` — retrieves the result set or affected rows

`conn:getfd()` — exposes the underlying file descriptor for integration with the event loop

This design maintains compatibility with synchronous environments: in drivers without native asynchronic support, `send_query` is executed immediately and `poll` returns false.

#200