### PR TITLE
sqlite3: fix incorrect boolean binding and spurious null bind in set_…

### DIFF
--- a/src/ls_sqlite3.c
+++ b/src/ls_sqlite3.c
@@ -404,13 +404,12 @@ static int set_param(lua_State *L, sqlite3_stmt *vm, int param_nr, int arg)
     case LUA_TSTRING: {
       size_t s_len;
       const char *s = lua_tolstring(L, arg, &s_len);
-      rc = sqlite3_bind_null(vm, param_nr);
       rc = sqlite3_bind_text(vm, param_nr, s, s_len, SQLITE_TRANSIENT);
       break;
     }
 
     case LUA_TBOOLEAN: {
-      int val = lua_tointeger(L, arg);
+      int val = lua_toboolean(L, arg);
       rc = sqlite3_bind_int(vm, param_nr, val);
       break;
     }


### PR DESCRIPTION
Fixes #203

Two fixes in `set_param()` in `src/ls_sqlite3.c`.

**1. LUA_TBOOLEAN: `lua_tointeger` → `lua_toboolean`**

`lua_tointeger()` on a boolean always returns 0, so `true` was stored as `0` — same as `false`. Changed to `lua_toboolean()`.

**2. LUA_TSTRING: remove spurious `sqlite3_bind_null()` call**

The null bind before `sqlite3_bind_text()` served no purpose and its return code was silently overwritten. Removed.
