### PR TITLE
[GSoC 2026] OCI8: Add Prepared Statement Support

### DIFF
--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -37,8 +37,8 @@ typedef struct {
 	short         closed;
 	short         loggedon;
 	short         auto_commit;        /* 0 for manual commit */
-	int           cur_counter;
-	int           stmt_counter;
+	int           cur_counter;  /* number of open cursors */
+	int           stmt_counter; /* number of open statements */
 	int           env;                /* reference to environment */
 	OCISvcCtx    *svchp;              /* service handle */
 	OCIError     *errhp; /* !!! */
@@ -48,7 +48,7 @@ typedef struct {
 	short       closed;
     OCIStmt    *stmthp;      /* statement handle, OCIStmtPrepare2 */
     OCIError   *errhp;      
-    int         conn;       
+    int         conn;        /* reference to connection in registry */
     ub2         type;        /* OCI_STMT_SELECT or DML */
     int         cursor_open; /* bool: 1 = cursor active, 0 = none */
 } stmt_data;
@@ -134,6 +134,22 @@ static stmt_data *getstatement (lua_State *L) {
 	luaL_argcheck (L, stmt != NULL, 1, LUASQL_PREFIX"statement expected");
 	luaL_argcheck (L, !stmt->closed, 1, LUASQL_PREFIX"statement is closed");
 	return stmt;
+}
+
+
+/*
+** Retrieve the environment from a connection's registry reference.
+** The connection stores a Lua registry ref to its parent environment;
+** this helper dereferences it and returns the env_data pointer.
+*/
+static env_data *getenvfromconn (lua_State *L, conn_data *conn) {
+	env_data *env;
+	lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
+	if (!lua_isuserdata (L, -1))
+		luaL_error (L, LUASQL_PREFIX"invalid environment in connection!");
+	env = (env_data *)lua_touserdata (L, -1);
+	lua_pop (L, 1);
+	return env;
 }
 
 
@@ -245,13 +261,12 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP
 		case SQLT_TIMESTAMP: {
-			env_data *env;
 			conn_data *conn;
+			env_data *env;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
-			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-			env = (env_data *)lua_touserdata (L, -1);
-			lua_pop (L, 2);
+			lua_pop (L, 1);
+			env = getenvfromconn (L, conn);
 			ASSERT (L, OCIDescriptorAlloc (env->envhp,(dvoid*)&(col->val.datetime),
 				OCI_DTYPE_TIMESTAMP, 0, (void **)0), cur->errhp);
 			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define), cur->errhp,
@@ -263,13 +278,12 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP_TZ
 		case SQLT_TIMESTAMP_TZ: {
-			env_data *env;
 			conn_data *conn;
+			env_data *env;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
-			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-			env = (env_data *)lua_touserdata (L, -1);
-			lua_pop (L, 2);
+			lua_pop (L, 1);
+			env = getenvfromconn (L, conn);
 			ASSERT (L, OCIDescriptorAlloc (env->envhp,(dvoid*)&(col->val.datetime),
 				OCI_DTYPE_TIMESTAMP_TZ, 0, (void **)0), cur->errhp);
 			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define), cur->errhp,
@@ -281,13 +295,12 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP_LTZ
 		case SQLT_TIMESTAMP_LTZ: {
-			env_data *env;
 			conn_data *conn;
+			env_data *env;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
-			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-			env = (env_data *)lua_touserdata (L, -1);
-			lua_pop (L, 2);
+			lua_pop (L, 1);
+			env = getenvfromconn (L, conn);
 			ASSERT (L, OCIDescriptorAlloc (env->envhp,(dvoid*)&(col->val.datetime),
 				OCI_DTYPE_TIMESTAMP_LTZ, 0, (void **)0), cur->errhp);
 			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define), cur->errhp,
@@ -307,13 +320,12 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 				(ub2 *)0, (ub4) OCI_DEFAULT), cur->errhp);
 			break;
 		case SQLT_CLOB: {
-			env_data *env;
 			conn_data *conn;
+			env_data *env;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
-			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-			env = (env_data *)lua_touserdata (L, -1);
-			lua_pop (L, 2);
+			lua_pop (L, 1);
+			env = getenvfromconn (L, conn);
 			ASSERT (L, OCIDescriptorAlloc (env->envhp, (dvoid *)&(col->val.s),
 				OCI_DTYPE_LOB, (size_t)0, (dvoid **)0), cur->errhp);
 			ASSERT (L, OCIDefineByPos (cur->stmthp, &(col->define),
@@ -432,9 +444,8 @@ static int pushvalue (lua_State *L, cur_data *cur, int i) {
 			env_data *env;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = lua_touserdata (L, -1);
-			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-			env = lua_touserdata (L, -1);
-			lua_pop (L, 2);
+			lua_pop (L, 1);
+			env = getenvfromconn (L, conn);
 			text buf[65];
 			ub4 buflen = sizeof(buf);
 			ASSERT (L, OCIDateTimeToText (env->envhp, cur->errhp, col->val.datetime,
@@ -449,9 +460,8 @@ static int pushvalue (lua_State *L, cur_data *cur, int i) {
 			env_data *env;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = lua_touserdata (L, -1);
-			lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-			env = lua_touserdata (L, -1);
-			lua_pop (L, 2);
+			lua_pop (L, 1);
+			env = getenvfromconn (L, conn);
 			ASSERT (L, OCILobGetLength (conn->svchp, cur->errhp,
 				(OCILobLocator *)col->val.s, &lob_len), cur->errhp);
 			if (lob_len > 0) {
@@ -704,8 +714,7 @@ static int conn_close (lua_State *L) {
 	if (conn->errhp)
 		OCIHandleFree ((dvoid *)conn->errhp, OCI_HTYPE_ERROR);
 	/* Decrement connection counter on environment object */
-	lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-	env = lua_touserdata (L, -1);
+	env = getenvfromconn (L, conn);
 	env->conn_counter--;
 	luaL_unref (L, LUA_REGISTRYINDEX, conn->env);
 
@@ -738,9 +747,7 @@ static int create_cursor (lua_State *L, int o, conn_data *conn, OCIStmt *stmt, c
 	cur->conn = luaL_ref (L, LUA_REGISTRYINDEX);
 
 	/* error handler */
-	lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-	env = lua_touserdata (L, -1);
-	lua_pop (L, 1);
+	env = getenvfromconn (L, conn);
 	ASSERT (L, OCIHandleAlloc((dvoid *) env->envhp,
 		(dvoid **) &(cur->errhp), (ub4) OCI_HTYPE_ERROR, (size_t) 0,
 		(dvoid **) 0), conn->errhp);
@@ -779,10 +786,7 @@ static int conn_execute (lua_State *L) {
 	OCIStmt *stmthp;
 
 	/* get environment */
-	lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-	if (!lua_isuserdata (L, -1))
-		luaL_error(L,LUASQL_PREFIX"invalid environment in connection!");
-	env = (env_data *)lua_touserdata (L, -1);
+	env = getenvfromconn (L, conn);
 	/* statement handle */
 	ASSERT (L, OCIHandleAlloc ((dvoid *)env->envhp, (dvoid **)&stmthp,
 		OCI_HTYPE_STMT, (size_t)0, (dvoid **)0), conn->errhp);
@@ -875,14 +879,11 @@ static int conn_prepare (lua_State *L) {
 	const char *statement = luaL_checkstring (L, 2);
 	ub2 type;
 	OCIStmt *stmthp;
+	OCIError *errhp = NULL;
 
 	/* get environment */
-	lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
-	if (!lua_isuserdata (L, -1))
-		luaL_error(L,LUASQL_PREFIX"invalid environment in connection!");
-	env = (env_data *)lua_touserdata (L, -1);
-	lua_pop (L, 1); 
-	
+	env = getenvfromconn (L, conn);
+
 	/* prepare statement via OCIStmtPrepare2 (allocates handle internally) */
 	ASSERT (L, OCIStmtPrepare2 (conn->svchp, &stmthp, conn->errhp,
 		(text *)statement, (ub4) strlen(statement),
@@ -890,28 +891,39 @@ static int conn_prepare (lua_State *L) {
 		(ub4) OCI_NTV_SYNTAX, (ub4) OCI_DEFAULT),
 		conn->errhp);
 
-	/* get statement type */
-	ASSERT (L, OCIAttrGet ((dvoid *)stmthp, (ub4) OCI_HTYPE_STMT,
-		(dvoid *)&type, (ub4 *)0, (ub4)OCI_ATTR_STMT_TYPE, conn->errhp),
-		conn->errhp);
+	/* get statement type. If it fails, release stmthp */
+	{
+		sword s = OCIAttrGet ((dvoid *)stmthp, (ub4) OCI_HTYPE_STMT,
+			(dvoid *)&type, (ub4 *)0, (ub4)OCI_ATTR_STMT_TYPE, conn->errhp);
+		if (s) {
+			OCIStmtRelease (stmthp, conn->errhp, NULL, 0, OCI_DEFAULT);
+			return checkerr (L, s, conn->errhp);
+		}
+	}
 
-	/* create a new statement userdata */
+	/* allocate error handle. If it fails, release stmthp */
+	{
+		sword s = OCIHandleAlloc ((dvoid *)env->envhp,
+			(dvoid **)&errhp, (ub4) OCI_HTYPE_ERROR, (size_t) 0,
+			(dvoid **) 0);
+		if (s) {
+			OCIStmtRelease (stmthp, conn->errhp, NULL, 0, OCI_DEFAULT);
+			return checkerr (L, s, conn->errhp);
+		}
+	}
+
+	/* Create userdata  */
 	stmt_data *stmt = (stmt_data *)LUASQL_NEWUD(L, sizeof(stmt_data));
 	luasql_setmeta (L, LUASQL_STATEMENT_OCI8);
 
 	/* fill in structure */
 	stmt->closed = 0;
 	stmt->stmthp = stmthp;
-	stmt->errhp = NULL;
+	stmt->errhp = errhp;
 	stmt->type = type;
 	stmt->cursor_open = 0;
 	lua_pushvalue (L, 1);
 	stmt->conn = luaL_ref (L, LUA_REGISTRYINDEX);
-
-	/* allocate a private error handle for the statement */
-	ASSERT (L, OCIHandleAlloc ((dvoid *)env->envhp,
-		(dvoid **)&(stmt->errhp), (ub4) OCI_HTYPE_ERROR, (size_t) 0,
-		(dvoid **) 0), conn->errhp);
 
 	conn->stmt_counter++;
 

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -1009,5 +1009,6 @@ LUASQL_API int luaopen_luasql_oci8 (lua_State *L) {
 	lua_newtable (L);
 	luaL_setfuncs (L, driver, 0);
 	luasql_set_info (L);
+	luasql_set_types (L);
 	return 1;
 }

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -37,11 +37,11 @@ typedef struct {
 	short         closed;
 	short         loggedon;
 	short         auto_commit;        /* 0 for manual commit */
-	int           cur_counter;  /* number of open cursors */
-	int           stmt_counter; /* number of open statements */
+	int           cur_counter;        /* number of open cursors */
+	int           stmt_counter;       /* number of open statements */
 	int           env;                /* reference to environment */
 	OCISvcCtx    *svchp;              /* service handle */
-	OCIError     *errhp; /* !!! */
+	OCIError     *errhp;              /* !!! */
 } conn_data;
 
 typedef struct {
@@ -85,7 +85,7 @@ typedef struct {
 	int           curr_tuple;         /* next tuple to be read */
 	char         *text;               /* text of SQL statement */
 	OCIStmt      *stmthp;             /* statement handle */
-	OCIError     *errhp; /* !!! */
+	OCIError     *errhp;              /* !!! */
 	column_data  *cols;               /* array of columns */
 } cur_data;
 
@@ -261,8 +261,8 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP
 		case SQLT_TIMESTAMP: {
-			conn_data *conn;
 			env_data *env;
+			conn_data *conn;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
 			lua_pop (L, 1);
@@ -278,8 +278,8 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP_TZ
 		case SQLT_TIMESTAMP_TZ: {
-			conn_data *conn;
 			env_data *env;
+			conn_data *conn;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
 			lua_pop (L, 1);
@@ -295,8 +295,8 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP_LTZ
 		case SQLT_TIMESTAMP_LTZ: {
-			conn_data *conn;
 			env_data *env;
+			conn_data *conn;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
 			lua_pop (L, 1);
@@ -320,8 +320,8 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 				(ub2 *)0, (ub4) OCI_DEFAULT), cur->errhp);
 			break;
 		case SQLT_CLOB: {
-			conn_data *conn;
 			env_data *env;
+			conn_data *conn;
 			lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
 			conn = (conn_data *)lua_touserdata (L, -1);
 			lua_pop (L, 1);
@@ -884,6 +884,16 @@ static int conn_prepare (lua_State *L) {
 	/* get environment */
 	env = getenvfromconn (L, conn);
 
+	/* Allocate userdata before OCI allocations so it doesn't leak on out of memory.
+	   Do NOT set the metatable yet to prevent __gc on uninitialized data. */
+	stmt_data *stmt = (stmt_data *)LUASQL_NEWUD(L, sizeof(stmt_data));
+	stmt->closed = 1;
+	stmt->stmthp = NULL;
+	stmt->errhp = NULL;
+	stmt->type = 0;
+	stmt->cursor_open = 0;
+	stmt->conn = LUA_NOREF;
+
 	/* prepare statement via OCIStmtPrepare2 (allocates handle internally) */
 	ASSERT (L, OCIStmtPrepare2 (conn->svchp, &stmthp, conn->errhp,
 		(text *)statement, (ub4) strlen(statement),
@@ -912,16 +922,13 @@ static int conn_prepare (lua_State *L) {
 		}
 	}
 
-	/* Create userdata  */
-	stmt_data *stmt = (stmt_data *)LUASQL_NEWUD(L, sizeof(stmt_data));
+	/* All OCI resources ready. Attach metatable and finalize fields. */
 	luasql_setmeta (L, LUASQL_STATEMENT_OCI8);
 
-	/* fill in structure */
 	stmt->closed = 0;
 	stmt->stmthp = stmthp;
 	stmt->errhp = errhp;
 	stmt->type = type;
-	stmt->cursor_open = 0;
 	lua_pushvalue (L, 1);
 	stmt->conn = luaL_ref (L, LUA_REGISTRYINDEX);
 

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -23,6 +23,7 @@
 #define LUASQL_ENVIRONMENT_OCI8 "Oracle environment"
 #define LUASQL_CONNECTION_OCI8 "Oracle connection"
 #define LUASQL_CURSOR_OCI8 "Oracle cursor"
+#define LUASQL_STATEMENT_OCI8 "Oracle statement"
 
 typedef struct {
 	short         closed;
@@ -37,11 +38,20 @@ typedef struct {
 	short         loggedon;
 	short         auto_commit;        /* 0 for manual commit */
 	int           cur_counter;
+	int           stmt_counter;
 	int           env;                /* reference to environment */
 	OCISvcCtx    *svchp;              /* service handle */
 	OCIError     *errhp; /* !!! */
 } conn_data;
 
+typedef struct {
+	short       closed;
+    OCIStmt    *stmthp;      /* statement handle, OCIStmtPrepare2 */
+    OCIError   *errhp;      
+    int         conn;       
+    ub2         type;        /* OCI_STMT_SELECT or DML */
+    int         cursor_open; /* bool: 1 = cursor active, 0 = none */
+} stmt_data;
 
 typedef union {
 	int     i;
@@ -114,6 +124,16 @@ static cur_data *getcursor (lua_State *L) {
 	luaL_argcheck (L, cur != NULL, 1, LUASQL_PREFIX"cursor expected");
 	luaL_argcheck (L, !cur->closed, 1, LUASQL_PREFIX"cursor is closed");
 	return cur;
+}
+
+/*
+** Check for valid statement.
+*/
+static stmt_data *getstatement (lua_State *L) {
+	stmt_data *stmt = (stmt_data *)luaL_checkudata (L, 1, LUASQL_STATEMENT_OCI8);
+	luaL_argcheck (L, stmt != NULL, 1, LUASQL_PREFIX"statement expected");
+	luaL_argcheck (L, !stmt->closed, 1, LUASQL_PREFIX"statement is closed");
+	return stmt;
 }
 
 
@@ -667,6 +687,11 @@ static int conn_close (lua_State *L) {
 		lua_pushstring (L, "There are open cursors");
 		return 2;
 	}
+	if (conn->stmt_counter > 0){
+		lua_pushboolean (L, 0);
+		lua_pushstring (L, "There are open statements");
+		return 2;
+	}
 
 	/* Nullify structure fields. */
 	conn->closed = 1;
@@ -801,6 +826,98 @@ static int conn_execute (lua_State *L) {
 	}
 }
 
+/*
+** Close a prepared statement.
+*/
+static int stmt_close (lua_State *L) {
+	conn_data *conn;
+	stmt_data *stmt = (stmt_data *)luaL_checkudata (L, 1, LUASQL_STATEMENT_OCI8);
+	luaL_argcheck (L, stmt != NULL, 1, LUASQL_PREFIX"statement expected");
+	if (stmt->closed) {
+		lua_pushboolean (L, 0);
+		lua_pushstring (L, "Statement is already closed");
+		return 2;
+	}
+	if (stmt->cursor_open) {
+		lua_pushboolean (L, 0);
+		lua_pushstring (L, LUASQL_PREFIX"cannot close statement with open cursor");
+		return 2;
+	}
+
+	stmt->closed = 1;
+	if (stmt->stmthp) {
+		OCIStmtRelease (stmt->stmthp, stmt->errhp, NULL, 0, OCI_DEFAULT);
+		stmt->stmthp = NULL;
+	}
+	if (stmt->errhp) {
+		OCIHandleFree ((dvoid *)stmt->errhp, OCI_HTYPE_ERROR);
+		stmt->errhp = NULL;
+	}
+
+	/* Decrement statement counter on connection object */
+	lua_rawgeti (L, LUA_REGISTRYINDEX, stmt->conn);
+	conn = lua_touserdata (L, -1);
+	conn->stmt_counter--;
+	luaL_unref (L, LUA_REGISTRYINDEX, stmt->conn);
+
+	lua_pushboolean (L, 1);
+	return 1;
+}
+
+
+/*
+** Prepares an SQL statement.
+** Returns the statement object.
+*/
+static int conn_prepare (lua_State *L) {
+	env_data *env;
+	conn_data *conn = getconnection (L);
+	const char *statement = luaL_checkstring (L, 2);
+	ub2 type;
+	OCIStmt *stmthp;
+
+	/* get environment */
+	lua_rawgeti (L, LUA_REGISTRYINDEX, conn->env);
+	if (!lua_isuserdata (L, -1))
+		luaL_error(L,LUASQL_PREFIX"invalid environment in connection!");
+	env = (env_data *)lua_touserdata (L, -1);
+	lua_pop (L, 1); 
+	
+	/* prepare statement via OCIStmtPrepare2 (allocates handle internally) */
+	ASSERT (L, OCIStmtPrepare2 (conn->svchp, &stmthp, conn->errhp,
+		(text *)statement, (ub4) strlen(statement),
+		(text *)NULL, (ub4) 0,
+		(ub4) OCI_NTV_SYNTAX, (ub4) OCI_DEFAULT),
+		conn->errhp);
+
+	/* get statement type */
+	ASSERT (L, OCIAttrGet ((dvoid *)stmthp, (ub4) OCI_HTYPE_STMT,
+		(dvoid *)&type, (ub4 *)0, (ub4)OCI_ATTR_STMT_TYPE, conn->errhp),
+		conn->errhp);
+
+	/* create a new statement userdata */
+	stmt_data *stmt = (stmt_data *)LUASQL_NEWUD(L, sizeof(stmt_data));
+	luasql_setmeta (L, LUASQL_STATEMENT_OCI8);
+
+	/* fill in structure */
+	stmt->closed = 0;
+	stmt->stmthp = stmthp;
+	stmt->errhp = NULL;
+	stmt->type = type;
+	stmt->cursor_open = 0;
+	lua_pushvalue (L, 1);
+	stmt->conn = luaL_ref (L, LUA_REGISTRYINDEX);
+
+	/* allocate a private error handle for the statement */
+	ASSERT (L, OCIHandleAlloc ((dvoid *)env->envhp,
+		(dvoid **)&(stmt->errhp), (ub4) OCI_HTYPE_ERROR, (size_t) 0,
+		(dvoid **) 0), conn->errhp);
+
+	conn->stmt_counter++;
+
+	return 1;
+}
+
 
 /*
 ** Commit the current transaction.
@@ -875,6 +992,7 @@ static int env_connect (lua_State *L) {
 	conn->closed = 1;
 	conn->auto_commit = 1;
 	conn->cur_counter = 0;
+	conn->stmt_counter = 0;
 	conn->loggedon = 0;
 	conn->svchp = NULL;
 	conn->errhp = NULL;
@@ -974,6 +1092,7 @@ static void create_metatables (lua_State *L) {
 		{"__close", conn_close},
 		{"close", conn_close},
 		{"execute", conn_execute},
+		{"prepare", conn_prepare},
 		{"commit", conn_commit},
 		{"rollback", conn_rollback},
 		{"setautocommit", conn_setautocommit},
@@ -989,10 +1108,17 @@ static void create_metatables (lua_State *L) {
 		{"numrows", cur_numrows},
 		{NULL, NULL},
 	};
+	struct luaL_Reg statement_methods[] = {
+		{"__gc", stmt_close},
+		{"__close", stmt_close},
+		{"close", stmt_close},
+		{NULL, NULL},
+	};
 	luasql_createmeta (L, LUASQL_ENVIRONMENT_OCI8, environment_methods);
 	luasql_createmeta (L, LUASQL_CONNECTION_OCI8, connection_methods);
 	luasql_createmeta (L, LUASQL_CURSOR_OCI8, cursor_methods);
-	lua_pop (L, 3);
+	luasql_createmeta (L, LUASQL_STATEMENT_OCI8, statement_methods);
+	lua_pop (L, 4);
 }
 
 

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -345,7 +345,7 @@ static int alloc_column_buffer (lua_State *L, cur_data *cur, int i) {
 /*
 ** Deallocate column buffers.
 */
-static int free_column_buffers (lua_State *L, cur_data *cur, int i) {
+static void free_column_buffers (lua_State *L, cur_data *cur, int i) {
 	/* column index ranges from 1 to numcols */
 	/* C array index ranges from 0 to numcols-1 */
 	column_data *col = &(cur->cols[i-1]);
@@ -368,32 +368,26 @@ static int free_column_buffers (lua_State *L, cur_data *cur, int i) {
 #endif
 #ifdef SQLT_TIMESTAMP
 		case SQLT_TIMESTAMP:
-			ASSERT (L, OCIDescriptorFree (col->val.datetime,
-				OCI_DTYPE_TIMESTAMP), cur->errhp);
+			OCIDescriptorFree (col->val.datetime, OCI_DTYPE_TIMESTAMP);
 			break;
 #endif
 #ifdef SQLT_TIMESTAMP_TZ
 		case SQLT_TIMESTAMP_TZ:
-			ASSERT (L, OCIDescriptorFree (col->val.datetime,
-				OCI_DTYPE_TIMESTAMP_TZ), cur->errhp);
+			OCIDescriptorFree (col->val.datetime, OCI_DTYPE_TIMESTAMP_TZ);
 			break;
 #endif
 #ifdef SQLT_TIMESTAMP_LTZ
 		case SQLT_TIMESTAMP_LTZ:
-			ASSERT (L, OCIDescriptorFree (col->val.datetime,
-				OCI_DTYPE_TIMESTAMP_LTZ), cur->errhp);
+			OCIDescriptorFree (col->val.datetime, OCI_DTYPE_TIMESTAMP_LTZ);
 			break;
 #endif
 		case SQLT_CLOB:
-			ASSERT (L, OCIDescriptorFree (col->val.s,
-				OCI_DTYPE_LOB), cur->errhp);
+			OCIDescriptorFree (col->val.s, OCI_DTYPE_LOB);
 			break;
 		default:
-			luaL_error (L, LUASQL_PREFIX"unknown type");
-			/*printf("free_buffers(): Unknown Type: %d count: %d\n",cols.item[count].type, count );*/
+			/* Ignore unknown types during cleanup */
 			break;
 	}
-    return 0;
 }
 
 
@@ -488,6 +482,50 @@ static int pushvalue (lua_State *L, cur_data *cur, int i) {
 
 
 /*
+** Closes the cursor and nullify all structure fields.
+*/
+static void cur_nullify (lua_State *L, cur_data *cur) {
+	int i;
+	conn_data *conn;
+
+	/* Deallocate buffers. */
+	for (i = 1; i <= cur->numcols; i++) {
+		free_column_buffers (L, cur, i);
+	}
+	free (cur->cols);
+	cur->cols = NULL;
+	free (cur->text);
+	cur->text = NULL;
+
+	/* Nullify structure fields. */
+	cur->closed = 1;
+	if (cur->stmthp) {
+		OCIHandleFree ((dvoid *)cur->stmthp, OCI_HTYPE_STMT);
+		cur->stmthp = NULL;
+	}
+	if (cur->errhp) {
+		OCIHandleFree ((dvoid *)cur->errhp, OCI_HTYPE_ERROR);
+		cur->errhp = NULL;
+	}
+
+	/* Decrement cursor counter on connection object */
+	if (cur->conn != LUA_NOREF) {
+		lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
+		conn = lua_touserdata (L, -1);
+		lua_pop (L, 1); /* Pop the connection object from the stack */
+		if (conn) conn->cur_counter--;
+		luaL_unref (L, LUA_REGISTRYINDEX, cur->conn);
+		cur->conn = LUA_NOREF;
+	}
+
+	luaL_unref (L, LUA_REGISTRYINDEX, cur->colnames);
+	cur->colnames = LUA_NOREF;
+	luaL_unref (L, LUA_REGISTRYINDEX, cur->coltypes);
+	cur->coltypes = LUA_NOREF;
+}
+
+
+/*
 ** Get another row of the given cursor.
 */
 static int cur_fetch (lua_State *L) {
@@ -496,7 +534,8 @@ static int cur_fetch (lua_State *L) {
 		OCI_FETCH_NEXT, OCI_DEFAULT);
 
 	if (status == OCI_NO_DATA) {
-		/* No more rows */
+		/* No more rows: auto-close the cursor */
+		cur_nullify (L, cur);
 		lua_pushnil (L);
 		return 1;
 	} else if (status != OCI_SUCCESS) {
@@ -546,8 +585,6 @@ static int cur_fetch (lua_State *L) {
 ** Return 1
 */
 static int cur_close (lua_State *L) {
-	int i;
-	conn_data *conn;
 	cur_data *cur = (cur_data *)luaL_checkudata (L, 1, LUASQL_CURSOR_OCI8);
 	luaL_argcheck (L, cur != NULL, 1, LUASQL_PREFIX"cursor expected");
 	if (cur->closed) {
@@ -556,31 +593,20 @@ static int cur_close (lua_State *L) {
 		return 2;
 	}
 
-	/* Deallocate buffers. */
-	for (i = 1; i <= cur->numcols; i++) {
-		int ret = free_column_buffers (L, cur, i);
-		if (ret)
-			return ret;
-	}
-	free (cur->cols);
-	free (cur->text);
-
-	/* Nullify structure fields. */
-	cur->closed = 1;
-	if (cur->stmthp)
-		OCIHandleFree ((dvoid *)cur->stmthp, OCI_HTYPE_STMT);
-	if (cur->errhp)
-		OCIHandleFree ((dvoid *)cur->errhp, OCI_HTYPE_ERROR);
-	/* Decrement cursor counter on connection object */
-	lua_rawgeti (L, LUA_REGISTRYINDEX, cur->conn);
-	conn = lua_touserdata (L, -1);
-	conn->cur_counter--;
-	luaL_unref (L, LUA_REGISTRYINDEX, cur->conn);
-	luaL_unref (L, LUA_REGISTRYINDEX, cur->colnames);
-	luaL_unref (L, LUA_REGISTRYINDEX, cur->coltypes);
+	cur_nullify (L, cur);
 
 	lua_pushboolean (L, 1);
 	return 1;
+}
+
+/*
+** Cursor object collector function
+*/
+static int cur_gc (lua_State *L) {
+	cur_data *cur = (cur_data *)luaL_checkudata (L, 1, LUASQL_CURSOR_OCI8);
+	if (cur != NULL && !(cur->closed))
+		cur_nullify (L, cur);
+	return 0;
 }
 
 
@@ -663,19 +689,6 @@ static int cur_getcoltypes (lua_State *L) {
 		lua_pushvalue (L, -1);
 		cur->coltypes = luaL_ref (L, LUA_REGISTRYINDEX);
 	}
-	return 1;
-}
-
-
-/*
-** Push the number of rows.
-*/
-static int cur_numrows (lua_State *L) {
-	int n;
-	cur_data *cur = getcursor (L);
-	ASSERT (L, OCIAttrGet ((dvoid *) cur->stmthp, OCI_HTYPE_STMT, (dvoid *)&n,
-		(ub4)0, OCI_ATTR_NUM_ROWS, cur->errhp), cur->errhp);
-	lua_pushnumber (L, n);
 	return 1;
 }
 
@@ -949,7 +962,8 @@ static int conn_commit (lua_State *L) {
 	if (conn->auto_commit == 0)
 		ASSERT (L, OCITransStart (conn->svchp, conn->errhp...
 */
-	return 0;
+	lua_pushboolean (L, 1);
+	return 1;
 }
 
 
@@ -964,7 +978,8 @@ static int conn_rollback (lua_State *L) {
 	if (conn->auto_commit == 0)
 		sql_begin(conn);
 */
-	return 0;
+	lua_pushboolean (L, 1);
+	return 1;
 }
 
 
@@ -1118,13 +1133,12 @@ static void create_metatables (lua_State *L) {
 		{NULL, NULL},
 	};
 	struct luaL_Reg cursor_methods[] = {
-		{"__gc", cur_close}, /* Should this method be changed? */
-		{"__close", cur_close},
+		{"__gc", cur_gc},
+		{"__close", cur_gc},
 		{"close", cur_close},
 		{"getcolnames", cur_getcolnames},
 		{"getcoltypes", cur_getcoltypes},
 		{"fetch", cur_fetch},
-		{"numrows", cur_numrows},
 		{NULL, NULL},
 	};
 	struct luaL_Reg statement_methods[] = {

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -950,6 +950,72 @@ static int conn_prepare (lua_State *L) {
 	return 1;
 }
 
+/*
+** Validates the Params table (bind_data)  [ This part is done and tested!! ]
+** bind the data with the Prepared Statement
+** execute the Prepared Statement
+** return a Cursor object if the statement is a query, otherwise
+** return the number of tuples affected by the statement.
+*/
+static int stmt_execute (lua_State *L) {
+    stmt_data *stmt = (stmt_data *)luaL_checkudata (L, 1, LUASQL_STATEMENT_OCI8);
+
+    if (stmt->cursor_open) {
+        lua_pushnil(L);
+        lua_pushstring(L, LUASQL_PREFIX"cannot execute: cursor still open");
+        return 2;
+    }
+
+    luaL_checktype(L, 2, LUA_TTABLE);
+
+    /* Validates the Params table (bind_data) */
+    int is_named;
+    if (!luasql_validate_params(L, 2, &is_named))
+        return 2;  /* nil+errmsg already on stack */
+
+    /* Binding part outline [ Not completed yet ] */
+    lua_pushnil(L);
+    while (lua_next(L, 2) != 0) {
+
+        /* fetching value and type: key at -2, value at -1 */
+        int luasql_type;
+        int is_null = 0;
+
+        if (lua_istable(L, -1)) {
+            /* {value, luasql.type} — get type from index 2 */
+            lua_rawgeti(L, -1, 2);
+            luasql_type = (int)lua_tointeger(L, -1);
+            lua_pop(L, 1);
+
+            if (luasql_type == LUASQL_TYPE_NULL)
+                is_null = 1;
+
+        } else {
+            /* luasql.type.null */
+            luasql_type = LUASQL_TYPE_NULL;
+            is_null = 1;
+        }
+
+        /* bind data */
+        if (is_named) {
+			/* If this driver won't support this feature, we will throw error */
+            const char *name = lua_tostring(L, -2);
+            /* ... OCIBindByName(stmt->stmthp, &bindhp, stmt->errhp,
+                                 name, strlen(name), ...) */
+        } else {
+			/* If this driver won't support this feature, we will throw error */
+            ub4 pos = (ub4)lua_tointeger(L, -2); /* 1-based, matches OCI */
+            /* ... OCIBindByPos(stmt->stmthp, &bindhp, stmt->errhp,
+                                pos, ...) */
+        }
+
+        lua_pop(L, 1); 
+    }
+
+    /* Execute Part */
+    return 0; 
+}
+
 
 /*
 ** Commit the current transaction.
@@ -1144,6 +1210,7 @@ static void create_metatables (lua_State *L) {
 	struct luaL_Reg statement_methods[] = {
 		{"__gc", stmt_close},
 		{"__close", stmt_close},
+		{"execute", stmt_execute},
 		{"close", stmt_close},
 		{NULL, NULL},
 	};

--- a/src/ls_oci8.c
+++ b/src/ls_oci8.c
@@ -951,8 +951,147 @@ static int conn_prepare (lua_State *L) {
 }
 
 /*
-** Validates the Params table (bind_data)  [ This part is done and tested!! ]
-** bind the data with the Prepared Statement
+** Helper function to parse 'YYYY-MM-DD' into an OCIDate struct.
+** Returns 1 on success, 0 on failure.
+*/
+#ifdef SQLT_ODT
+static int parse_date(const char *date_str, OCIDate *date) {
+	int year, month, day;
+	if (sscanf(date_str, "%4d-%2d-%2d", &year, &month, &day) == 3) {
+		OCIDateSetDate(date, year, month, day);
+		OCIDateSetTime(date, 0, 0, 0);
+		return 1;
+	}
+	return 0;
+}
+#endif
+
+/*
+** Binds parameters to a prepared statement.
+** Returns 0 on success, or a Lua return value on error.
+*/
+static int stmt_bind (lua_State *L, stmt_data *stmt, int num_params, int is_named,
+                      column_value **p_bind_values, OCIBind ***p_bind_handles, sb2 **p_inds) {
+    column_value *bind_values = (column_value *)calloc(num_params, sizeof(column_value));
+    OCIBind **bind_handles = (OCIBind **)calloc(num_params, sizeof(OCIBind *));
+    sb2 *inds = (sb2 *)calloc(num_params, sizeof(sb2));
+
+    *p_bind_values = bind_values;
+    *p_bind_handles = bind_handles;
+    *p_inds = inds;
+
+    int param_idx = 0;
+    lua_pushnil(L);
+    while (lua_next(L, 2) != 0) {
+        /* fetching value and type: key at -2, value at -1 */
+        int luasql_type;
+        int is_null = 0;
+
+        if (lua_istable(L, -1)) {
+            /* {value, luasql.type} — get type from index 2 */
+            lua_rawgeti(L, -1, 2);
+            luasql_type = (int)lua_tointeger(L, -1);
+            lua_pop(L, 1);
+            if (luasql_type == LUASQL_TYPE_NULL)
+                is_null = 1;
+        } else {
+            /* luasql.type.null */
+            luasql_type = LUASQL_TYPE_NULL;
+            is_null = 1;
+        }
+
+        dvoid *bind_ptr = NULL;
+        sb4 bind_size = 0;
+        ub2 bind_type = 0;
+
+        if (!is_null) {
+            inds[param_idx] = 0; /* not null */
+            lua_rawgeti(L, -1, 1);
+            switch (luasql_type) {
+                case LUASQL_TYPE_INT:
+                    bind_values[param_idx].i = (int)lua_tointeger(L, -1);
+                    bind_ptr = &bind_values[param_idx].i;
+                    bind_size = sizeof(int);
+                    bind_type = SQLT_INT;
+                    break;
+                case LUASQL_TYPE_NUMBER:
+                    bind_values[param_idx].d = (double)lua_tonumber(L, -1);
+                    bind_ptr = &bind_values[param_idx].d;
+                    bind_size = sizeof(double);
+                    bind_type = SQLT_FLT;
+                    break;
+                case LUASQL_TYPE_BOOLEAN:
+                    bind_values[param_idx].s = lua_toboolean(L, -1) ? "1" : "0";
+                    bind_ptr = bind_values[param_idx].s;
+                    bind_size = 1;
+                    bind_type = SQLT_CHR;
+                    break;
+                case LUASQL_TYPE_STRING:
+                case LUASQL_TYPE_TIME:
+                case LUASQL_TYPE_TIMESTAMP:
+                    bind_values[param_idx].s = (char *)lua_tostring(L, -1);
+                    bind_ptr = bind_values[param_idx].s;
+                    bind_size = strlen(bind_values[param_idx].s) + 1;
+                    bind_type = SQLT_STR;
+                    break;
+                case LUASQL_TYPE_DATE: {
+                    const char *date_str = lua_tostring(L, -1);
+#ifdef SQLT_ODT
+                    if (!parse_date(date_str, &bind_values[param_idx].date)) {
+                        lua_pushnil(L);
+                        lua_pushstring(L, LUASQL_PREFIX"invalid date format, expected YYYY-MM-DD");
+                        return 2;
+                    }
+                    bind_ptr = &bind_values[param_idx].date;
+                    bind_size = sizeof(OCIDate);
+                    bind_type = SQLT_ODT;
+#else
+                    bind_values[param_idx].s = (char *)date_str;
+                    bind_ptr = bind_values[param_idx].s;
+                    bind_size = strlen(bind_values[param_idx].s) + 1;
+                    bind_type = SQLT_STR;
+#endif
+                    break;
+                }
+            }
+            lua_pop(L, 1);
+        } else {
+            inds[param_idx] = -1; /* NULL */
+            bind_type = SQLT_STR; /* default safe type for null */
+            bind_size = 0;
+            bind_ptr = NULL;
+        }
+
+        /* bind data */
+        sword status;
+        if (is_named) {
+            const char *name = lua_tostring(L, -2);
+            status = OCIBindByName(stmt->stmthp, &bind_handles[param_idx], stmt->errhp,
+                                   (text *)name, strlen(name),
+                                   bind_ptr, bind_size, bind_type,
+                                   (dvoid *)&inds[param_idx], (ub2 *)0, (ub2 *)0,
+                                   (ub4)0, (ub4 *)0, OCI_DEFAULT);
+        } else {
+            ub4 pos = (ub4)lua_tointeger(L, -2); /*OCI also follows 1-based indexing*/
+            status = OCIBindByPos(stmt->stmthp, &bind_handles[param_idx], stmt->errhp,
+                                  pos, bind_ptr, bind_size, bind_type,
+                                  (dvoid *)&inds[param_idx], (ub2 *)0, (ub2 *)0,
+                                  (ub4)0, (ub4 *)0, OCI_DEFAULT);
+        }
+
+        if (status) {
+            return checkerr(L, status, stmt->errhp);
+        }
+
+        param_idx++;
+        lua_pop(L, 1); 
+    }
+    return 0;
+}
+
+/*
+** Validates the Params table (bind_data)  
+** bind the data with the Prepared Statement [ Upto this part is done! ]
 ** execute the Prepared Statement
 ** return a Cursor object if the statement is a query, otherwise
 ** return the number of tuples affected by the statement.
@@ -970,50 +1109,32 @@ static int stmt_execute (lua_State *L) {
 
     /* Validates the Params table (bind_data) */
     int is_named;
-    if (!luasql_validate_params(L, 2, &is_named))
+    int num_params = 0;
+    if (!luasql_validate_params(L, 2, &is_named, &num_params))
         return 2;  /* nil+errmsg already on stack */
 
-    /* Binding part outline [ Not completed yet ] */
-    lua_pushnil(L);
-    while (lua_next(L, 2) != 0) {
+    column_value *bind_values = NULL;
+    OCIBind **bind_handles = NULL;
+    sb2 *inds = NULL;
 
-        /* fetching value and type: key at -2, value at -1 */
-        int luasql_type;
-        int is_null = 0;
-
-        if (lua_istable(L, -1)) {
-            /* {value, luasql.type} — get type from index 2 */
-            lua_rawgeti(L, -1, 2);
-            luasql_type = (int)lua_tointeger(L, -1);
-            lua_pop(L, 1);
-
-            if (luasql_type == LUASQL_TYPE_NULL)
-                is_null = 1;
-
-        } else {
-            /* luasql.type.null */
-            luasql_type = LUASQL_TYPE_NULL;
-            is_null = 1;
+    if (num_params > 0) {
+        int ret = stmt_bind(L, stmt, num_params, is_named, &bind_values, &bind_handles, &inds);
+        if (ret) {
+            if (bind_values) free(bind_values);
+            if (bind_handles) free(bind_handles);
+            if (inds) free(inds);
+            return ret;
         }
-
-        /* bind data */
-        if (is_named) {
-			/* If this driver won't support this feature, we will throw error */
-            const char *name = lua_tostring(L, -2);
-            /* ... OCIBindByName(stmt->stmthp, &bindhp, stmt->errhp,
-                                 name, strlen(name), ...) */
-        } else {
-			/* If this driver won't support this feature, we will throw error */
-            ub4 pos = (ub4)lua_tointeger(L, -2); /* 1-based, matches OCI */
-            /* ... OCIBindByPos(stmt->stmthp, &bindhp, stmt->errhp,
-                                pos, ...) */
-        }
-
-        lua_pop(L, 1); 
     }
 
-    /* Execute Part */
-    return 0; 
+    /* Execute part comes here - not implemented yet */
+
+    /* Free bind data */
+    if (bind_values) free(bind_values);
+    if (bind_handles) free(bind_handles);
+    if (inds) free(inds);
+
+    return 0;
 }
 
 

--- a/src/luasql.c
+++ b/src/luasql.c
@@ -117,9 +117,41 @@ LUASQL_API void luasql_setmeta (lua_State *L, const char *name) {
 
 
 /*
+** __index metamethod for the "type" table.
+** Only called when a key is NOT found in the table, so valid lookups
+** (e.g. luasql.type.int) have zero overhead.  On a miss it throws an
+** informative error listing every valid type name.
+*/
+static int luasql_type_index (lua_State *L) {
+	const char *key = luaL_checkstring (L, 2);
+	luaL_Buffer b;
+	int first = 1;
+
+	luaL_buffinit (L, &b);
+	luaL_addstring (&b, LUASQL_PREFIX "invalid type '");
+	luaL_addstring (&b, key);
+	luaL_addstring (&b, "', expected one of: ");
+
+	/* iterate the type table (arg 1) to collect valid key names */
+	lua_pushnil (L);
+	while (lua_next (L, 1) != 0) {
+		if (!first)
+			luaL_addstring (&b, ", ");
+		luaL_addstring (&b, lua_tostring (L, -2));
+		first = 0;
+		lua_pop (L, 1);  /* pop value, keep key for next iteration */
+	}
+
+	luaL_pushresult (&b);
+	return lua_error (L);
+}
+
+
+/*
 ** Creates a "type" sub-table on the module table (assumed on top of stack).
 ** Registers driver-agnostic type constants: int, number, string, boolean,
 ** date, time, timestamp, null.
+** Sets an __index metamethod that throws on unknown keys.
 */
 LUASQL_API void luasql_set_types (lua_State *L) {
 	lua_newtable (L);
@@ -139,6 +171,13 @@ LUASQL_API void luasql_set_types (lua_State *L) {
 	lua_setfield (L, -2, "timestamp");
 	lua_pushinteger (L, LUASQL_TYPE_NULL);
 	lua_setfield (L, -2, "null");
+
+	/* attach metatable with __index that errors on unknown keys */
+	lua_newtable (L);                                  /* metatable */
+	lua_pushcfunction (L, luasql_type_index);
+	lua_setfield (L, -2, "__index");
+	lua_setmetatable (L, -2);              /* setmetatable(type_tbl, mt) */
+
 	lua_setfield (L, -2, "type");
 }
 

--- a/src/luasql.c
+++ b/src/luasql.c
@@ -117,6 +117,41 @@ LUASQL_API void luasql_setmeta (lua_State *L, const char *name) {
 
 
 /*
+** Creates a "type" sub-table on the module table (assumed on top of stack).
+** Registers driver-agnostic type constants: int, number, string, boolean,
+** date, time, timestamp, null.
+*/
+LUASQL_API void luasql_set_types (lua_State *L) {
+	lua_newtable (L);
+	lua_pushliteral (L, "int");
+	lua_pushinteger (L, LUASQL_TYPE_INT);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "number");
+	lua_pushinteger (L, LUASQL_TYPE_NUMBER);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "string");
+	lua_pushinteger (L, LUASQL_TYPE_STRING);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "boolean");
+	lua_pushinteger (L, LUASQL_TYPE_BOOLEAN);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "date");
+	lua_pushinteger (L, LUASQL_TYPE_DATE);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "time");
+	lua_pushinteger (L, LUASQL_TYPE_TIME);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "timestamp");
+	lua_pushinteger (L, LUASQL_TYPE_TIMESTAMP);
+	lua_settable (L, -3);
+	lua_pushliteral (L, "null");
+	lua_pushinteger (L, LUASQL_TYPE_NULL);
+	lua_settable (L, -3);
+	lua_setfield (L, -2, "type");
+}
+
+
+/*
 ** Assumes the table is on top of the stack.
 */
 LUASQL_API void luasql_set_info (lua_State *L) {

--- a/src/luasql.c
+++ b/src/luasql.c
@@ -123,30 +123,22 @@ LUASQL_API void luasql_setmeta (lua_State *L, const char *name) {
 */
 LUASQL_API void luasql_set_types (lua_State *L) {
 	lua_newtable (L);
-	lua_pushliteral (L, "int");
 	lua_pushinteger (L, LUASQL_TYPE_INT);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "number");
+	lua_setfield (L, -2, "int");
 	lua_pushinteger (L, LUASQL_TYPE_NUMBER);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "string");
+	lua_setfield (L, -2, "number");
 	lua_pushinteger (L, LUASQL_TYPE_STRING);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "boolean");
+	lua_setfield (L, -2, "string");
 	lua_pushinteger (L, LUASQL_TYPE_BOOLEAN);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "date");
+	lua_setfield (L, -2, "boolean");
 	lua_pushinteger (L, LUASQL_TYPE_DATE);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "time");
+	lua_setfield (L, -2, "date");
 	lua_pushinteger (L, LUASQL_TYPE_TIME);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "timestamp");
+	lua_setfield (L, -2, "time");
 	lua_pushinteger (L, LUASQL_TYPE_TIMESTAMP);
-	lua_settable (L, -3);
-	lua_pushliteral (L, "null");
+	lua_setfield (L, -2, "timestamp");
 	lua_pushinteger (L, LUASQL_TYPE_NULL);
-	lua_settable (L, -3);
+	lua_setfield (L, -2, "null");
 	lua_setfield (L, -2, "type");
 }
 

--- a/src/luasql.c
+++ b/src/luasql.c
@@ -15,6 +15,10 @@
 	lua_pushstring(L, "" s, (sizeof(s)/sizeof(char))-1)
 #endif
 
+#if LUA_VERSION_NUM < 502
+#define lua_rawlen lua_objlen
+#endif
+
 
 /*
 ** Typical database error situation
@@ -189,14 +193,16 @@ LUASQL_API void luasql_set_types (lua_State *L) {
 ** Returns 1 on success.
 ** Returns 0 on failure — pushes nil + errmsg onto the stack.
 */
-LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_out) {
+LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_out, int *num_params_out) {
     int is_named = -1;  /* -1=unknown, 1=named, 0=positional */
+    int param_count = 0;
     
     /* Convert tbl_idx to absolute index to prevent it from changing when we push nil */
     int abs_tbl_idx = (tbl_idx < 0) ? lua_gettop(L) + tbl_idx + 1 : tbl_idx;
 
     lua_pushnil(L);
     while (lua_next(L, abs_tbl_idx) != 0) {
+        param_count++;
         /* key at -2, value at -1 */
 
         /* check if keys are named or positional */
@@ -294,6 +300,7 @@ LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_
     }
 
     *is_named_out = (is_named == 1) ? 1 : 0;
+    if (num_params_out) *num_params_out = param_count;
     return 1;
 }
 

--- a/src/luasql.c
+++ b/src/luasql.c
@@ -181,6 +181,122 @@ LUASQL_API void luasql_set_types (lua_State *L) {
 	lua_setfield (L, -2, "type");
 }
 
+/*
+** Validates the entire params table passed to stmt:execute().
+** tbl_idx: absolute stack index of the params table.
+** is_named_out: set to 1 if string keys (named), 0 if integer keys (positional).
+**
+** Returns 1 on success.
+** Returns 0 on failure — pushes nil + errmsg onto the stack.
+*/
+LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_out) {
+    int is_named = -1;  /* -1=unknown, 1=named, 0=positional */
+    
+    /* Convert tbl_idx to absolute index to prevent it from changing when we push nil */
+    int abs_tbl_idx = (tbl_idx < 0) ? lua_gettop(L) + tbl_idx + 1 : tbl_idx;
+
+    lua_pushnil(L);
+    while (lua_next(L, abs_tbl_idx) != 0) {
+        /* key at -2, value at -1 */
+
+        /* check if keys are named or positional */
+        int key_type = lua_type(L, -2);
+        if (key_type != LUA_TSTRING && key_type != LUA_TNUMBER) {
+            lua_pop(L, 2);
+            lua_pushnil(L);
+            lua_pushstring(L, LUASQL_PREFIX "parameter keys must be strings or integers");
+            return 0;
+        }
+
+        int key_is_str = (key_type == LUA_TSTRING);
+        if (is_named == -1) {
+            is_named = key_is_str ? 1 : 0;
+        } else if (is_named != (key_is_str ? 1 : 0)) {
+            lua_pop(L, 2);
+            lua_pushnil(L);
+            lua_pushstring(L, LUASQL_PREFIX "cannot mix positional and named parameters");
+            return 0;
+        }
+
+        /* validate value entry */
+        if (lua_istable(L, -1)) {
+            /* must be exactly {value, luasql.type.X} — length 2 */
+            if (lua_rawlen(L, -1) != (size_t)2) {
+                lua_pop(L, 2);
+                lua_pushnil(L);
+                lua_pushstring(L, LUASQL_PREFIX "parameter must be {value, luasql.type.X}");
+                return 0;
+            }
+
+            /* get type (index 2) */
+            lua_rawgeti(L, -1, 2);
+            if (lua_type(L, -1) != LUA_TNUMBER) {
+                lua_pop(L, 3);
+                lua_pushnil(L);
+                lua_pushstring(L, LUASQL_PREFIX "second element must be a luasql.type constant");
+                return 0;
+            }
+            int luasql_type = (int)lua_tointeger(L, -1);
+            lua_pop(L, 1);  /* pop type */
+
+            /* validate type constant range */
+            if (luasql_type < 0 || luasql_type >= LUASQL_TYPE_COUNT) {
+                lua_pop(L, 2);
+                lua_pushnil(L);
+                lua_pushfstring(L, LUASQL_PREFIX "unknown luasql.type constant: %d", luasql_type);
+                return 0;
+            }
+
+            /* get value (index 1) */
+            lua_rawgeti(L, -1, 1);
+
+            /* validate value matches type */
+            int ok = 1;
+            switch (luasql_type) {
+                case LUASQL_TYPE_INT:
+                case LUASQL_TYPE_NUMBER:
+                    ok = (lua_type(L, -1) == LUA_TNUMBER);
+                    break;
+                case LUASQL_TYPE_STRING:
+                case LUASQL_TYPE_DATE:
+                case LUASQL_TYPE_TIME:
+                case LUASQL_TYPE_TIMESTAMP:
+                    ok = (lua_type(L, -1) == LUA_TSTRING);
+                    break;
+                case LUASQL_TYPE_BOOLEAN:
+                    ok = lua_isboolean(L, -1);
+                    break;
+                case LUASQL_TYPE_NULL:
+                    ok = 1;  /* value doesn't matter when type is null */
+                    break;
+            }
+            lua_pop(L, 1);  /* pop value */
+
+            if (!ok) {
+                lua_pop(L, 2);
+                lua_pushnil(L);
+                lua_pushstring(L, LUASQL_PREFIX "value does not match declared luasql.type");
+                return 0;
+            }
+
+        } else if (lua_type(L, -1) == LUA_TNUMBER && (int)lua_tointeger(L, -1) == LUASQL_TYPE_NULL) {
+            /* bare luasql.type.null constant — always valid */
+
+        } else {
+            /* anything else is an error */
+            lua_pop(L, 2);
+            lua_pushnil(L);
+            lua_pushstring(L, LUASQL_PREFIX "parameter must be {value, luasql.type.X} " "or luasql.type.null");
+            return 0;
+        }
+
+        lua_pop(L, 1);  /* pop value, keep key for next iteration */
+    }
+
+    *is_named_out = (is_named == 1) ? 1 : 0;
+    return 1;
+}
+
 
 /*
 ** Assumes the table is on top of the stack.

--- a/src/luasql.h
+++ b/src/luasql.h
@@ -24,6 +24,16 @@
 #define LUASQL_CONNECTION "Each driver must have a connection metatable"
 #define LUASQL_CURSOR "Each driver must have a cursor metatable"
 
+/* Prepared-statement type constants (driver-agnostic) */
+#define LUASQL_TYPE_INT       0
+#define LUASQL_TYPE_NUMBER    1
+#define LUASQL_TYPE_STRING    2
+#define LUASQL_TYPE_BOOLEAN   3
+#define LUASQL_TYPE_DATE      4
+#define LUASQL_TYPE_TIME      5
+#define LUASQL_TYPE_TIMESTAMP 6
+#define LUASQL_TYPE_NULL      7
+
 // Macro to handle userdata creation across Lua versions
 #if LUA_VERSION_NUM >= 504
 #define LUASQL_NEWUD(L, size) lua_newuserdatauv(L, size, 0)
@@ -36,6 +46,7 @@ LUASQL_API int luasql_failmsg (lua_State *L, const char *err, const char *m);
 LUASQL_API int luasql_createmeta (lua_State *L, const char *name, const luaL_Reg *methods);
 LUASQL_API void luasql_setmeta (lua_State *L, const char *name);
 LUASQL_API void luasql_set_info (lua_State *L);
+LUASQL_API void luasql_set_types (lua_State *L);
 
 #if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);

--- a/src/luasql.h
+++ b/src/luasql.h
@@ -33,6 +33,7 @@
 #define LUASQL_TYPE_TIME      5
 #define LUASQL_TYPE_TIMESTAMP 6
 #define LUASQL_TYPE_NULL      7
+#define LUASQL_TYPE_COUNT     8 // Always place it in the last. Used in validating the range of type constants. 
 
 // Macro to handle userdata creation across Lua versions
 #if LUA_VERSION_NUM >= 504
@@ -47,6 +48,7 @@ LUASQL_API int luasql_createmeta (lua_State *L, const char *name, const luaL_Reg
 LUASQL_API void luasql_setmeta (lua_State *L, const char *name);
 LUASQL_API void luasql_set_info (lua_State *L);
 LUASQL_API void luasql_set_types (lua_State *L);
+LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_out);
 
 #if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);

--- a/src/luasql.h
+++ b/src/luasql.h
@@ -48,7 +48,7 @@ LUASQL_API int luasql_createmeta (lua_State *L, const char *name, const luaL_Reg
 LUASQL_API void luasql_setmeta (lua_State *L, const char *name);
 LUASQL_API void luasql_set_info (lua_State *L);
 LUASQL_API void luasql_set_types (lua_State *L);
-LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_out);
+LUASQL_API int luasql_validate_params (lua_State *L, int tbl_idx, int *is_named_out, int *num_params_out);
 
 #if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);

--- a/tests/oci8.lua
+++ b/tests/oci8.lua
@@ -2,8 +2,19 @@
 -- Oracle specific tests and configurations.
 ---------------------------------------------------------------------
 
-table.insert (CUR_METHODS, "numrows")
-table.insert (EXTENSIONS, numrows)
+-- NOTE: For Unicode tests to work correctly, set NLS_LANG=.AL32UTF8
+-- in your environment before running the test suite.
 
 DEFINITION_STRING_TYPE_NAME = "varchar(60)"
 QUERYING_STRING_TYPE_NAME = "string"
+
+-- Oracle Autonomous Database enables parallel DML by default, which
+-- causes ORA-12838 when mixing DML and SELECT in the same transaction.
+-- Wrap the rollback test to disable parallel DML for this session.
+local _orig_rollback = rollback
+function rollback ()
+	-- Disable parallel DML to avoid ORA-12838 on Autonomous DB
+	assert(CONN:execute("ALTER SESSION DISABLE PARALLEL DML"),
+		"couldn't disable parallel DML")
+	return _orig_rollback()
+end

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -762,6 +762,25 @@ function numrows()
 	io.write (" numrows")
 end
 
+---------------------------------------------------------------------
+-- Test luasql.type constants and the __index error on unknown keys.
+---------------------------------------------------------------------
+function type_constants_test ()
+	assert (type(luasql.type) == "table", "luasql.type is not a table")
+
+	-- check each constant exists and is a number
+	local expected = { "int", "number", "string", "boolean", "date", "time", "timestamp", "null" }
+	for _, name in ipairs(expected) do
+		assert2 ("number", type(luasql.type[name]),
+			"luasql.type."..name.." should be a number")
+	end
+
+	-- check that an unknown key raises an error
+	local ok, err = pcall(function () return luasql.type.nul end)
+	assert2 (false, ok, "luasql.type.nul should raise an error")
+	assert (err:find("nul"), "error message should mention the unknown key")
+end
+
 
 ---------------------------------------------------------------------
 -- Main
@@ -798,6 +817,7 @@ password = arg[4] or DEFAULT_PASSWORD or nil
 -- Complete set of tests
 tests = {
 	{ "basic checking", basic_test },
+	{ "type constants", type_constants_test },
 	{ "create table", create_table },
 	{ "fetch two values", fetch2 },
 	{ "fetch new table", fetch_new_table },
@@ -824,7 +844,7 @@ else
 	luasql = require ("luasql."..driver)
 	local major, minor = _VERSION:match" (%d)%.(%d+)"
 	if tonumber(minor) >= 4 then
-		table.insert (tests, 11, { "to-be-closed support", to_be_closed_support })
+		table.insert (tests, #tests - 2, { "to-be-closed support", to_be_closed_support })
 	end
 end
 assert (luasql, "Could not load driver: no luasql table.")

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -448,7 +448,7 @@ function unicode_values ()
 	local row = { cur:fetch () }
 	assert2 ("string", type(row[1]), "error while trying to fetch values")
 	assert2 ("1", row[1], "wrong value: expecting '1', got '"..tostring (row[1]).."'")
-	assert2 ("Áêìõü", row[2], "wrong value: expecting 'Áêìõü', got '"..tostring (row[1]).."'")
+	assert2 ("Áêìõü", row[2], "wrong value: expecting 'Áêìõü', got '"..tostring (row[2]).."'")
 	assert2 (nil, cur:fetch (row))
 	assert2 (false, cur:close(), MSG_CURSOR_NOT_CLOSED)
 	-- fetch row based on Unicode value
@@ -768,17 +768,24 @@ end
 function type_constants_test ()
 	assert (type(luasql.type) == "table", "luasql.type is not a table")
 
-	-- check each constant exists and is a number
-	local expected = { "int", "number", "string", "boolean", "date", "time", "timestamp", "null" }
-	for _, name in ipairs(expected) do
-		assert2 ("number", type(luasql.type[name]),
-			"luasql.type."..name.." should be a number")
-	end
-
-	-- check that an unknown key raises an error
+	-- check that an unknown key raises an error and lists exactly all expected types
 	local ok, err = pcall(function () return luasql.type.nul end)
 	assert2 (false, ok, "luasql.type.nul should raise an error")
-	assert (err:find("nul"), "error message should mention the unknown key")
+
+	-- The error message lists types in an undefined order (table iteration).
+	-- We extract them, sort them, and compare against the expected list.
+	local prefix = "LuaSQL: invalid type 'nul', expected one of: "
+	local msg_start = err:find(prefix, 1, true)
+	assert (msg_start, "error message missing expected prefix: " .. tostring(err))
+	
+	local types = {}
+	for t in err:sub(msg_start + #prefix):gmatch("[^, ]+") do
+		table.insert(types, t)
+	end
+	table.sort(types)
+
+	assert2 ("boolean, date, int, null, number, string, time, timestamp", table.concat(types, ", "),
+		"luasql.type contains unexpected or missing types")
 end
 
 


### PR DESCRIPTION
Part of #207

This PR adds the first implementation part:

- `luasql_set_types()` -> driver-agnostic type constants exposed as `luasql.type.*`
- `conn:prepare(sql)` -> prepares a statement using `OCIStmtPrepare2`
- `stmt:close()` -> releases the statement using `OCIStmtRelease`
- `stmt_data` struct with `stmthp`, `errhp`, `conn`, `type`, `cursor_open`

Mid-term evaluation is done. Now proceeding with:
- `stmt:execute()` 

This PR is marked as Draft