### PR TITLE
feat(mysql): align async `get_result` multi-statement behavior with postgres

### DIFF
--- a/src/ls_mysql.c
+++ b/src/ls_mysql.c
@@ -67,6 +67,7 @@ typedef struct {
 	short      closed;
 	int        env;                /* reference to environment */
 	MYSQL     *my_conn;
+	short      query_started;      /* flag to track if a query was just started */
 } conn_data;
 
 typedef struct {
@@ -497,6 +498,7 @@ static int conn_send_query (lua_State *L) {
 	size_t st_len;
 	const char *statement = luaL_checklstring (L, 2, &st_len);
 	int status, ret;
+	conn->query_started = 1;
 #ifdef MYSQL_OPT_NONBLOCK
 	status = mysql_real_query_start(&ret, conn->my_conn, statement, st_len);
 #else
@@ -526,7 +528,30 @@ static int conn_poll (lua_State *L) {
 
 static int conn_get_result (lua_State *L) {
 	conn_data *conn = getconnection (L);
-	MYSQL_RES *res = mysql_store_result(conn->my_conn);
+	MYSQL_RES *res = NULL;
+	short has_result = 0;
+
+	if (conn->query_started) {
+		conn->query_started = 0;
+		res = mysql_store_result(conn->my_conn);
+		has_result = 1;
+	} else {
+		if (mysql_more_results(conn->my_conn)) {
+			int ret = mysql_next_result(conn->my_conn);
+			if (ret == 0) {
+				res = mysql_store_result(conn->my_conn);
+				has_result = 1;
+			} else if (ret > 0) {
+				return luasql_failmsg(L, "error retrieving next result. MySQL: ", mysql_error(conn->my_conn));
+			}
+		}
+	}
+
+	if (!has_result) {
+		lua_pushnil(L);
+		return 1;
+	}
+
 	unsigned int num_cols = mysql_field_count(conn->my_conn);
 
 	if (res) { /* tuples returned */
@@ -634,6 +659,7 @@ static int create_connection (lua_State *L, int env, MYSQL *const my_conn) {
 	conn->closed = 0;
 	conn->env = LUA_NOREF;
 	conn->my_conn = my_conn;
+	conn->query_started = 0;
 	lua_pushvalue (L, env);
 	conn->env = luaL_ref (L, LUA_REGISTRYINDEX);
 	return 1;


### PR DESCRIPTION
## Summary

This PR makes `conn:get_result()` behave the same way for MySQL/MariaDB as it already does for PostgreSQL when using the async API.

With PostgreSQL, you can simply keep calling `conn:get_result()` until it returns `nil`. For MySQL/MariaDB, only the first result set was returned, leaving any remaining results pending on the connection. That could eventually lead to the familiar:

```text
CR_COMMANDS_OUT_OF_SYNC:
Commands out of sync; you can't run this command now
```

The goal of this change is to make the async API behave consistently regardless of the database backend.

## What changed

- Added a `query_started` flag to the `conn_data` structure.
- Initialized `query_started` in `create_connection()`.
- Set `query_started` whenever `conn_send_query()` starts a new query.
- Updated `conn_get_result()` to:
  - return the first result set after a query starts;
  - automatically call `mysql_more_results()` and `mysql_next_result()` on subsequent calls;
  - continue returning result sets until none remain;
  - return `nil` once the connection has been fully drained.

With this change, applications can use the same async loop for both PostgreSQL and MySQL/MariaDB:

```lua
while true do
    local res, err = conn:get_result()

    if err then
        handle_error(err)
    end

    if not res then
        break
    end

    process_result(res)
end
```

Besides simplifying the API, this also avoids `CR_COMMANDS_OUT_OF_SYNC` errors by ensuring all pending result sets are consumed before the connection is reused.  #211